### PR TITLE
Annual disturbances

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -50,6 +50,13 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1vwyp_i4rLncT2L1ukOvOI20DFxfYuni5/view?usp=drive_link" 
     ),
     expectsInput(
+      objectName = "disturbanceMeta", objectClass = "data.table",
+      desc = paste("Table defining the disturbance event types.", 
+                   "This associates CBM-CFS3 disturbances with the",
+                   "event IDs in the 'disturbanceEvents' table."),
+      sourceURL("TODO")
+    ),
+    expectsInput(
       objectName = "ecozones", objectClass = "data.table",
       desc = paste("A data.table with the ecozone for each pixelId. Used to determine",
                    "the equation parameters to split the above ground biomass into",
@@ -73,6 +80,10 @@ defineModule(sim, list(
       objectName = "rasterToMatch", objectClass =  "SpatRaster",
       desc = "Template raster to use for simulations; defaults is the RIA study area.", 
       sourceURL = "https://drive.google.com/file/d/1LUEiVMUWd_rlG9AAFan7zKyoUs22YIX2/view?usp=drive_link"
+    ),
+    expectsInput(
+      objectName = "rstCurrentBurn", objectClass = "SpatRaster",
+      desc = "Raster of fires with 1 indicating burned pixels."
     ),
     expectsInput(
       objectName = "studyArea", objectClass =  "sfc",
@@ -122,7 +133,13 @@ defineModule(sim, list(
       desc = paste("Increments (metric tonnes of tree biomass/ha) in each pool",
                    "for each pixel and cohort. Gets updated at each timestep.",
                    "Columns are `pixelId`, `speciesCode`, `age`, `merchInc`, `foliageInc`, and `otherInc`.")
-    ),    
+    ),
+    createsOutput(
+      objectName = "disturbanceEvents",
+      objectClass = "data.table",
+      desc = paste("Table with disturbance events for each simulation year.",
+                   "Events types are defined in the 'disturbanceMeta' table.")
+    ),
     createsOutput(
       objectName = "summaryAGB",
       objectClass = "data.table",

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -573,7 +573,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::rast",
       destinationPath = inputPath(sim),
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsRTM")
   }
   
   if (!suppliedElsewhere("masterRaster", sim)) {
@@ -590,7 +590,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::vect",
       destinationPath = inputPath(sim),
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsSA")
   }
   
   # pixel groups from vegetation data that gets updated annually
@@ -601,7 +601,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::rast",
       to = sim$rasterToMatch,
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsPGM")
   }
   
   if(inherits(sim$studyArea, "SpatVector")){
@@ -620,7 +620,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::vect",
       to = studyAreaBuffered,
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsEcozones")
     ez <- rasterize(ecozones, sim$rasterToMatch, field = "ECOZONE")
     sim$ecozones <- data.table(ecozone = as.integer(ez[]))
     sim$ecozones <- sim$ecozones[, pixelIndex := .I] |> na.omit()
@@ -639,7 +639,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::vect",
       to = studyAreaBuffered,
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsJurisdictions")
     juris_id <- rasterize(jurisdictions, sim$rasterToMatch, field = "PRUID")
     juris_id <- as.data.table(juris_id, na.rm = FALSE)
     juris_id$PRUID <- as.integer(as.character(juris_id$PRUID))
@@ -654,7 +654,7 @@ AnnualDisturbances <- function(sim){
                              fun = "data.table::fread",
                              destinationPath = inputPath(sim),
                              filename2 = "appendix2_table6_tb.csv",
-                             overwrite = TRUE) |> Cache()
+                             overwrite = TRUE) |> Cache(userTags = "prepInputsTable6")
   }
   
   if (!suppliedElsewhere("table7", sim)) {
@@ -662,7 +662,7 @@ AnnualDisturbances <- function(sim){
                              fun = "data.table::fread",
                              destinationPath = inputPath(sim),
                              filename2 = "appendix2_table7_tb.csv",
-                             overwrite = TRUE) |> Cache()
+                             overwrite = TRUE) |> Cache(userTags = "prepInputsTable7")
   }
   
   
@@ -674,7 +674,7 @@ AnnualDisturbances <- function(sim){
                                     fun = "data.table::fread",
                                     destinationPath = inputPath(sim),
                                     filename2 = "yieldTablesId.csv",
-                                    overwrite = TRUE) |> Cache()
+                                    overwrite = TRUE) |> Cache(userTags = "prepInputsYTId")
   }
   if(!all(c("gcid", "pixelIndex") %in% colnames(sim$yieldTablesId))) {
     stop("yieldTablesId needs the columns gcid and pixelIndex")
@@ -686,7 +686,7 @@ AnnualDisturbances <- function(sim){
                                   fun = "data.table::fread",
                                   destinationPath = inputPath(sim),
                                   filename2 = "yieldTablesCumulative.csv",
-                                  overwrite = TRUE) |> Cache()
+                                  overwrite = TRUE) |> Cache(userTags = "prepInputsYTC")
   }
   if(!all(c("gcid", "speciesCode", "biomass", "age") %in% colnames(sim$yieldTablesCumulative))) {
     stop("yieldTablesCumulative needs the columns gcid, age, biomass, and speciesCode")
@@ -699,7 +699,7 @@ AnnualDisturbances <- function(sim){
                                  destinationPath = inputPath(sim),
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
-                                 filename2 = "cohortData.csv") |> Cache()
+                                 filename2 = "cohortData.csv") |> Cache(userTags = "prepInputsCD")
   }
   if(!all(c("pixelGroup", "speciesCode", "B", "age") %in% colnames(sim$cohortData))) {
     stop("cohortData needs the columns pixelGroup, age, B, and speciesCode")
@@ -718,7 +718,7 @@ AnnualDisturbances <- function(sim){
                                  destinationPath = inputPath(sim),
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
-                                 filename2 = "disturbanceMeta.csv") |> Cache()
+                                 filename2 = "disturbanceMeta.csv") |> Cache(userTags = "prepInputsDistMeta")
   }
   if(!all(c("eventID", "distName") %in% colnames(sim$disturbanceMeta))) {
     stop("disturbanceMeta needs the columns eventID and distName")

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -54,7 +54,7 @@ defineModule(sim, list(
       desc = paste("Table defining the disturbance event types.", 
                    "This associates CBM-CFS3 disturbances with the",
                    "event IDs in the 'disturbanceEvents' table."),
-      sourceURL("TODO")
+      sourceURL("https://drive.google.com/file/d/11nIiLeRwgA7R7Lw685WIfb6HPGjM6kiB/view?usp=drive_link")
     ),
     expectsInput(
       objectName = "ecozones", objectClass = "data.table",
@@ -649,12 +649,14 @@ AnnualIncrements <- function(sim){
 
   #4. Cohort data. Information on biomass for each cohort and pixel group. Gets updated
   # annually.
-  if (!suppliedElsewhere("cohortData", sim))
+  if (!suppliedElsewhere("cohortData", sim)){
     sim$cohortData <- prepInputs(url = extractURL("cohortData"),
                                  destinationPath = inputPath(sim),
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
                                  filename2 = "cohortData.csv") |> Cache()
+  }
+
   
   # TODO will be used for plotting to keep the same colors of species as in LandR modules
   # if (!suppliedElsewhere("sppColorVect", sim)){
@@ -662,6 +664,20 @@ AnnualIncrements <- function(sim){
   #   sim$sppColorVect <- RColorBrewer::brewer.pal(n = length(sp), name = 'Accent')
   #   names(sim$sppColorVect) <- sp
   # }
+  
+  # 5. Disturbance meta
+  if (!suppliedElsewhere("disturbanceMeta", sim)) {
+    sim$cohortData <- prepInputs(url = extractURL("disturbanceMeta"),
+                                 destinationPath = inputPath(sim),
+                                 fun = "data.table::fread",
+                                 overwrite = TRUE,
+                                 filename2 = "disturbanceMeta.csv") |> Cache()
+  }
+
+  if (!suppliedElsewhere("rstCurrentBurn", sim)) {
+    sim$rstCurrentBurn <- sim$rasterToMatch
+    sim$rstCurrentBurn[] <- NA
+  }
   
   return(invisible(sim))
 }

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -64,7 +64,7 @@ defineModule(sim, list(
       sourceURL = "http://sis.agr.gc.ca/cansis/nsdb/ecostrat/zone/ecozone_shp.zip"
     ),
     expectsInput(
-      objectName = "juridictions", objectClass = "data.table",
+      objectName = "jurisdictions", objectClass = "data.table",
       desc = paste("A data.table with the province/territory for each pixelIndex.", 
                    "Used to determine the equation parameters to split the above", 
                    "ground biomass into carbon pools."),
@@ -363,7 +363,7 @@ SplitYieldTables <- function(sim) {
   # Spatial Matching
   spatialDT <- spatialMatch(
     pixelGroupMap = sim$yieldTablesId,
-    juridictions = sim$juridictions,
+    jurisdictions = sim$jurisdictions,
     ecozones = sim$ecozones
   ) |> na.omit()
   
@@ -490,7 +490,7 @@ AnnualIncrements <- function(sim){
   # 3. split cohort data of current year
   spatialDT <- spatialMatch(
     pixelGroupMap = sim$pixelGroupMap,
-    juridictions = sim$juridictions,
+    jurisdictions = sim$jurisdictions,
     ecozones = sim$ecozones
   ) |> na.omit()
   
@@ -627,25 +627,25 @@ AnnualDisturbances <- function(sim){
     setcolorder(sim$ecozones, c("pixelIndex", "ecozone"))
   }
   
-  if (!suppliedElsewhere("juridictions", sim)) {
+  if (!suppliedElsewhere("jurisdictions", sim)) {
     dt <- data.table(
       PRUID = c(10, 11, 12, 13, 24, 35, 46, 47, 48, 59, 60, 61, 62),
       juris_id = c("NL", "PE", "NS", "NB", "QC", "ON", "MB", "SK", "AB", "BC", "YT", "NT", "NU")
     )
     
-    juridictions <- prepInputs(
-      url = extractURL("juridictions"),
+    jurisdictions <- prepInputs(
+      url = extractURL("jurisdictions"),
       destinationPath = inputPath(sim),
       fun = "terra::vect",
       to = studyAreaBuffered,
       overwrite = TRUE
     ) |> Cache()
-    juris_id <- rasterize(juridictions, sim$rasterToMatch, field = "PRUID")
+    juris_id <- rasterize(jurisdictions, sim$rasterToMatch, field = "PRUID")
     juris_id <- as.data.table(juris_id, na.rm = FALSE)
     juris_id$PRUID <- as.integer(as.character(juris_id$PRUID))
-    sim$juridictions <- dt[juris_id, on = "PRUID"]
-    sim$juridictions <- sim$juridictions[, pixelIndex := .I] |> na.omit()
-    setcolorder(sim$juridictions, c("pixelIndex", "PRUID", "juris_id"))
+    sim$jurisdictions <- dt[juris_id, on = "PRUID"]
+    sim$jurisdictions <- sim$jurisdictions[, pixelIndex := .I] |> na.omit()
+    setcolorder(sim$jurisdictions, c("pixelIndex", "PRUID", "juris_id"))
   }
   
   # 2. NFI params

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -1,27 +1,27 @@
 spatialMatch <- function(pixelGroupMap, juridictions, ecozones){
   if(is.data.table(pixelGroupMap)) {
-    if(all(c("pixelId", "gcid") %in% names(pixelGroupMap))) {
+    if(all(c("pixelIndex", "gcid") %in% names(pixelGroupMap))) {
       spatialMatch <- pixelGroupMap
     } else {
-      stop("The data table pixelGroupMap need to have the column `pixelId`and `gcid`")
+      stop("The data table pixelGroupMap need to have the column `pixelIndex`and `gcid`")
     }
   } else if (inherits(pixelGroupMap, "SpatRaster")) {
     spatialMatch <- data.table(
       pixelGroup = as.integer(pixelGroupMap[])
     ) 
-    spatialMatch <- spatialMatch[, pixelId := .I] |> na.omit()
+    spatialMatch <- spatialMatch[, pixelIndex := .I] |> na.omit()
   } else {
     stop("The object pixelGroupMap needs to be a data.table or a SpatRaster")
   }
-  if (any(!(spatialMatch$pixelId %in% ecozones$pixelId))) {
+  if (any(!(spatialMatch$pixelIndex %in% ecozones$pixelIndex))) {
     stop("There is a problem: some pixels cannot be matched to an ecozone...")
   }
-  spatialMatch <- spatialMatch[ecozones, on = "pixelId"]
+  spatialMatch <- spatialMatch[ecozones, on = "pixelIndex"]
   
-  if (any(!(spatialMatch$pixelId %in% juridictions$pixelId))) {
+  if (any(!(spatialMatch$pixelIndex %in% juridictions$pixelIndex))) {
     stop("There is a problem: some pixels cannot be matched to a juridiction...")
   }
-  spatialMatch <- spatialMatch[juridictions, on = "pixelId"]
+  spatialMatch <- spatialMatch[juridictions, on = "pixelIndex"]
   return(spatialMatch)
 }
 

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -1,4 +1,4 @@
-spatialMatch <- function(pixelGroupMap, juridictions, ecozones){
+spatialMatch <- function(pixelGroupMap, jurisdictions, ecozones){
   if(is.data.table(pixelGroupMap)) {
     if(all(c("pixelIndex", "gcid") %in% names(pixelGroupMap))) {
       spatialMatch <- pixelGroupMap
@@ -18,10 +18,10 @@ spatialMatch <- function(pixelGroupMap, juridictions, ecozones){
   }
   spatialMatch <- spatialMatch[ecozones, on = "pixelIndex"]
   
-  if (any(!(spatialMatch$pixelIndex %in% juridictions$pixelIndex))) {
-    stop("There is a problem: some pixels cannot be matched to a juridiction...")
+  if (any(!(spatialMatch$pixelIndex %in% jurisdictions$pixelIndex))) {
+    stop("There is a problem: some pixels cannot be matched to a jurisdiction...")
   }
-  spatialMatch <- spatialMatch[juridictions, on = "pixelIndex"]
+  spatialMatch <- spatialMatch[jurisdictions, on = "pixelIndex"]
   return(spatialMatch)
 }
 

--- a/tests/testthat/test-1-matchCurveToCohort.R
+++ b/tests/testthat/test-1-matchCurveToCohort.R
@@ -3,18 +3,18 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   # test spatialMatch with pixelGroupDT
   set.seed(1)
   nonforested <- sample(c(1:9), 3)
-  pixelGroup <- data.table(pixelId = c(1:9),
+  pixelGroup <- data.table(pixelIndex = c(1:9),
                            gcid = c(rep(1,3), rep(2,3), rep(3,3)))
   pixelGroup <- pixelGroup[-nonforested,]
   
-  juridictions <- data.table(pixelId = c(1:9),
+  juridictions <- data.table(pixelIndex = c(1:9),
                              juridiction = c(rep("a", 5), rep("b", 4)))
-  ecozones <- data.table(pixelId = c(1:9),
+  ecozones <- data.table(pixelIndex = c(1:9),
                          ecozone = c(rep(1, 2), rep(2, 5), rep(1, 2)))
   out1 <- spatialMatch(pixelGroup, juridictions, ecozones)
   
   expect_is(out1, "data.table")
-  expect_named(out1, c("pixelId", "gcid", "ecozone", "juridiction"))
+  expect_named(out1, c("pixelIndex", "gcid", "ecozone", "juridiction"))
   expect_equal(out1$ecozone, ecozones$ecozone)
   expect_equal(out1$juridiction, juridictions$juridiction)
   expect_true(all(is.na(out1$gcid[nonforested])))
@@ -26,7 +26,7 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   pixelGroupMap[nonforested] <- NA
   out2 <- spatialMatch(pixelGroupMap, juridictions, ecozones)
   expect_is(out2, "data.table")
-  expect_named(out2, c("pixelId", "pixelGroup", "ecozone", "juridiction"), ignore.order = T)
+  expect_named(out2, c("pixelIndex", "pixelGroup", "ecozone", "juridiction"), ignore.order = T)
   expect_equal(out2$ecozone, ecozones$ecozone)
   expect_equal(out2$juridiction, juridictions$juridiction)
   expect_true(all(is.na(out2$gcid[nonforested])))
@@ -34,7 +34,7 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   # test addSpatialUnits with yield tables
   spatialUnits <- na.omit(out1)
   spatialUnits[, newgcid := .GRP, by = .(gcid, ecozone, juridiction)]
-  spatialUnits <- unique(spatialUnits[, pixelId := NULL])
+  spatialUnits <- unique(spatialUnits[, pixelIndex := NULL])
   LandR_species = c("Abie_las", "Betu_pap", "Pice_gla")
   yieldTables <- data.table(
     expand.grid(speciesCode = LandR_species, 

--- a/tests/testthat/test-1-matchCurveToCohort.R
+++ b/tests/testthat/test-1-matchCurveToCohort.R
@@ -7,16 +7,16 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
                            gcid = c(rep(1,3), rep(2,3), rep(3,3)))
   pixelGroup <- pixelGroup[-nonforested,]
   
-  juridictions <- data.table(pixelIndex = c(1:9),
-                             juridiction = c(rep("a", 5), rep("b", 4)))
+  jurisdictions <- data.table(pixelIndex = c(1:9),
+                             jurisdiction = c(rep("a", 5), rep("b", 4)))
   ecozones <- data.table(pixelIndex = c(1:9),
                          ecozone = c(rep(1, 2), rep(2, 5), rep(1, 2)))
-  out1 <- spatialMatch(pixelGroup, juridictions, ecozones)
+  out1 <- spatialMatch(pixelGroup, jurisdictions, ecozones)
   
   expect_is(out1, "data.table")
-  expect_named(out1, c("pixelIndex", "gcid", "ecozone", "juridiction"))
+  expect_named(out1, c("pixelIndex", "gcid", "ecozone", "jurisdiction"))
   expect_equal(out1$ecozone, ecozones$ecozone)
-  expect_equal(out1$juridiction, juridictions$juridiction)
+  expect_equal(out1$jurisdiction, jurisdictions$jurisdiction)
   expect_true(all(is.na(out1$gcid[nonforested])))
 
     # test spatialMatch with spatRast
@@ -24,16 +24,16 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
     matrix(data = c(rep(1,3), rep(2, 3), rep(3, 3)), nrow = 3, ncol = 3)
   )
   pixelGroupMap[nonforested] <- NA
-  out2 <- spatialMatch(pixelGroupMap, juridictions, ecozones)
+  out2 <- spatialMatch(pixelGroupMap, jurisdictions, ecozones)
   expect_is(out2, "data.table")
-  expect_named(out2, c("pixelIndex", "pixelGroup", "ecozone", "juridiction"), ignore.order = T)
+  expect_named(out2, c("pixelIndex", "pixelGroup", "ecozone", "jurisdiction"), ignore.order = T)
   expect_equal(out2$ecozone, ecozones$ecozone)
-  expect_equal(out2$juridiction, juridictions$juridiction)
+  expect_equal(out2$jurisdiction, jurisdictions$jurisdiction)
   expect_true(all(is.na(out2$gcid[nonforested])))
   
   # test addSpatialUnits with yield tables
   spatialUnits <- na.omit(out1)
-  spatialUnits[, newgcid := .GRP, by = .(gcid, ecozone, juridiction)]
+  spatialUnits[, newgcid := .GRP, by = .(gcid, ecozone, jurisdiction)]
   spatialUnits <- unique(spatialUnits[, pixelIndex := NULL])
   LandR_species = c("Abie_las", "Betu_pap", "Pice_gla")
   yieldTables <- data.table(
@@ -44,7 +44,7 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   
   expect_true(all(LandR_species %in% out3$speciesCode))
   expect_equal(nrow(out3), 15)
-  expect_named(out3, c("gcid", "speciesCode", "ecozone", "juridiction"), ignore.order = TRUE)
+  expect_named(out3, c("gcid", "speciesCode", "ecozone", "jurisdiction"), ignore.order = TRUE)
 
   # test with cohortData
   cohortData <- data.table(
@@ -56,12 +56,12 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   
   expect_true(all(LandR_species %in% out4$speciesCode))
   expect_equal(nrow(out4), 15)
-  expect_named(out4, c("pixelGroup", "speciesCode", "ecozone", "juridiction"), ignore.order = TRUE)
+  expect_named(out4, c("pixelGroup", "speciesCode", "ecozone", "jurisdiction"), ignore.order = TRUE)
   
   # test add CanfiCode
   out5 <- addCanfiCode(out3)
   expect_equal(nrow(out5), nrow(out3))
-  expect_named(out5, c("speciesCode", "ecozone", "juridiction", "gcid", "canfi_species"), ignore.order = TRUE)
+  expect_named(out5, c("speciesCode", "ecozone", "jurisdiction", "gcid", "canfi_species"), ignore.order = TRUE)
   expect_true(all(out5$canfi_species[out5$speciesCode == "Abie_las"] == 304))
   expect_true(all(out5$canfi_species[out5$speciesCode == "Betu_pap"] == 1303))
   expect_true(all(out5$canfi_species[out5$speciesCode == "Pice_gla"] == 105))

--- a/tests/testthat/test-2-LandRCBM_split3pools.R
+++ b/tests/testthat/test-2-LandRCBM_split3pools.R
@@ -16,7 +16,7 @@ test_that("module runs with small example", {
                               destinationPath = spadesTestPaths$temp$inputs,
                               filename2 = "yieldTablesId.csv",
                               overwrite = TRUE)
-  yieldTablesId$pixelId[c(1:ncell(rtm))] <- c(1:ncell(rtm))
+  yieldTablesId$pixelIndex[c(1:ncell(rtm))] <- c(1:ncell(rtm))
   yieldTablesId <- yieldTablesId[c(1:ncell(rtm)), ]
   
   yieldTablesCumulative <- prepInputs(url = "https://drive.google.com/file/d/1ePPc_a8u6K_Sefd_wVS3E9BiSqK9DOnO/view?usp=drive_link",
@@ -74,8 +74,8 @@ test_that("module runs with small example", {
   
   # check yieldTablesId
   expect_is(simTest$yieldTablesId, "data.table")
-  expect_named(simTest$yieldTablesId, c("pixelId", "gcid"), ignore.order = TRUE)
-  expect_setequal(simTest$yieldTablesId$pixelId, yieldTablesId$pixelId)
+  expect_named(simTest$yieldTablesId, c("pixelIndex", "gcid"), ignore.order = TRUE)
+  expect_setequal(simTest$yieldTablesId$pixelIndex, yieldTablesId$pixelIndex)
   expect_equal(length(unique(simTest$yieldTablesId$gcid)), length(unique(yieldTablesId$gcid)))
   expect_setequal(simTest$yieldTablesId$gcid, simTest$yieldTablesCumulative$gcid)
 
@@ -90,19 +90,19 @@ test_that("module runs with small example", {
   # check aboveGroundBiomass
   expect_is(simTest$aboveGroundBiomass, "data.table")
   expect_named(simTest$aboveGroundBiomass,
-               c("pixelId", "speciesCode", "age", "merch", "foliage", "other"),
+               c("pixelIndex", "speciesCode", "age", "merch", "foliage", "other"),
                ignore.order = TRUE)
   
   # check aboveGroundIncrements
   expect_is(simTest$aboveGroundIncrements, "data.table")
   expect_named(
     simTest$aboveGroundIncrements, 
-    c("pixelId", "speciesCode", "age", "merchInc", "foliageInc", "otherInc"),
+    c("pixelIndex", "speciesCode", "age", "merchInc", "foliageInc", "otherInc"),
     ignore.order = TRUE
   )
   expect_equal(sum(simTest$aboveGroundIncrements$merchInc), 0 ) # there is not growth/mortality in the test
 
-  #check summaryAGB
+  # check summaryAGB
   expect_is(simTest$summaryAGB, "data.table")
   expect_named(
     simTest$summaryAGB, 
@@ -110,5 +110,14 @@ test_that("module runs with small example", {
     ignore.order = TRUE
   )
   expect_contains(simTest$summaryAGB$year, c(2011:2016))
+  
+  # check disturbanceEvents
+  expect_is(simTest$disturbanceEvents, "data.table")
+  expect_named(
+    simTest$disturbanceEvents, 
+    c("pixelIndex", "year", "eventID"),
+    ignore.order = TRUE
+  )
+  expect_equal(nrow(simTest$disturbanceEvents), 0)
   
 })


### PR DESCRIPTION
This adds the event `annualDisturbances`. 

Each year, the module extract the pixels that were burned and update the object `disturbanceEvents `: a data.table with columns `pixelIndex`, `year`, `eventID`.  This object would be used to transfer disturbances from `LandR` to `CBM`. So far, only fires are included, but this could include other types of disturbances in the future.