### PR TITLE
Getting module outputs closer to CBM inputs!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ inputs/
 R/4.2/
 figures/
 .secrets
+.Rprofile

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -50,6 +50,13 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1vwyp_i4rLncT2L1ukOvOI20DFxfYuni5/view?usp=drive_link" 
     ),
     expectsInput(
+      objectName = "disturbanceMeta", objectClass = "data.table",
+      desc = paste("Table defining the disturbance event types.", 
+                   "This associates CBM-CFS3 disturbances with the",
+                   "event IDs in the 'disturbanceEvents' table."),
+      sourceURL("TODO")
+    ),
+    expectsInput(
       objectName = "ecozones", objectClass = "data.table",
       desc = paste("A data.table with the ecozone for each pixelId. Used to determine",
                    "the equation parameters to split the above ground biomass into",
@@ -73,6 +80,10 @@ defineModule(sim, list(
       objectName = "rasterToMatch", objectClass =  "SpatRaster",
       desc = "Template raster to use for simulations; defaults is the RIA study area.", 
       sourceURL = "https://drive.google.com/file/d/1LUEiVMUWd_rlG9AAFan7zKyoUs22YIX2/view?usp=drive_link"
+    ),
+    expectsInput(
+      objectName = "rstCurrentBurn", objectClass = "SpatRaster",
+      desc = "Raster of fires with 1 indicating burned pixels."
     ),
     expectsInput(
       objectName = "studyArea", objectClass =  "sfc",
@@ -122,7 +133,13 @@ defineModule(sim, list(
       desc = paste("Increments (metric tonnes of tree biomass/ha) in each pool",
                    "for each pixel and cohort. Gets updated at each timestep.",
                    "Columns are `pixelId`, `speciesCode`, `age`, `merchInc`, `foliageInc`, and `otherInc`.")
-    ),    
+    ),
+    createsOutput(
+      objectName = "disturbanceEvents",
+      objectClass = "data.table",
+      desc = paste("Table with disturbance events for each simulation year.",
+                   "Events types are defined in the 'disturbanceMeta' table.")
+    ),
     createsOutput(
       objectName = "summaryAGB",
       objectClass = "data.table",

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -632,7 +632,7 @@ AnnualDisturbances <- function(sim){
   } else {
     stop("studyArea needs to be a SpatVector or a sf polygon")
   }
-
+  
   # ecozones
   if (!suppliedElsewhere("ecozones", sim)) {
     ecozones <- prepInputs(
@@ -669,18 +669,6 @@ AnnualDisturbances <- function(sim){
     setcolorder(sim$jurisdictions, c("pixelIndex", "PRUID", "juris_id"))
   }
   
-  # Stand Age
-  if (!suppliedElsewhere("standAgeMap", sim)) {
-    sim$pixelGroupMap <- prepInputs(
-      url = extractURL("standAgeMap"),
-      destinationPath = inputPath(sim),
-      fun = "terra::rast",
-      to = sim$rasterToMatch,
-      overwrite = TRUE
-    ) |> Cache(userTags = "prepInputsSAM")
-  }
-  
-  
   # 2. NFI params
   if (!suppliedElsewhere("table6", sim)) {
     sim$table6 <- prepInputs(url = extractURL("table6"),
@@ -708,21 +696,24 @@ AnnualDisturbances <- function(sim){
                                     destinationPath = inputPath(sim),
                                     filename2 = "yieldTablesId.csv",
                                     overwrite = TRUE) |> Cache(userTags = "prepInputsYTId")
+  } else if (!is.null(sim$yieldTablesId)) {
+    if(!all(c("gcid", "pixelIndex") %in% colnames(sim$yieldTablesId))) {
+      stop("yieldTablesId needs the columns gcid and pixelIndex")
+    }
   }
-  if(!all(c("gcid", "pixelIndex") %in% colnames(sim$yieldTablesId))) {
-    stop("yieldTablesId needs the columns gcid and pixelIndex")
-  }
+  
   
   # actual yield curves
   if (!suppliedElsewhere("yieldTablesCumulative", sim)) {
     sim$yieldTablesCumulative <- prepInputs(url = extractURL("yieldTablesCumulative"),
-                                  fun = "data.table::fread",
-                                  destinationPath = inputPath(sim),
-                                  filename2 = "yieldTablesCumulative.csv",
-                                  overwrite = TRUE) |> Cache(userTags = "prepInputsYTC")
-  }
-  if(!all(c("gcid", "speciesCode", "biomass", "age") %in% colnames(sim$yieldTablesCumulative))) {
-    stop("yieldTablesCumulative needs the columns gcid, age, biomass, and speciesCode")
+                                            fun = "data.table::fread",
+                                            destinationPath = inputPath(sim),
+                                            filename2 = "yieldTablesCumulative.csv",
+                                            overwrite = TRUE) |> Cache(userTags = "prepInputsYTC")
+  } else if (!is.null(sim$yieldTablesCumulative)) {
+    if(!all(c("gcid", "speciesCode", "biomass", "age") %in% colnames(sim$yieldTablesCumulative))){
+      stop("yieldTablesCumulative needs the columns gcid, age, biomass, and speciesCode")
+    }
   }
   
   #4. Cohort data. Information on biomass for each cohort and pixel group. Gets updated
@@ -733,9 +724,10 @@ AnnualDisturbances <- function(sim){
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
                                  filename2 = "cohortData.csv") |> Cache(userTags = "prepInputsCD")
-  }
-  if(!all(c("pixelGroup", "speciesCode", "B", "age") %in% colnames(sim$cohortData))) {
-    stop("cohortData needs the columns pixelGroup, age, B, and speciesCode")
+  } else if (!is.null(sim$cohortData)) {
+    if(!all(c("pixelGroup", "speciesCode", "B", "age") %in% colnames(sim$cohortData))){
+      stop("cohortData needs the columns pixelGroup, age, B, and speciesCode")
+    }
   }
   
   # TODO will be used for plotting to keep the same colors of species as in LandR modules
@@ -748,15 +740,16 @@ AnnualDisturbances <- function(sim){
   # 5. Disturbance meta
   if (!suppliedElsewhere("disturbanceMeta", sim)) {
     sim$disturbanceMeta <- prepInputs(url = extractURL("disturbanceMeta"),
-                                 destinationPath = inputPath(sim),
-                                 fun = "data.table::fread",
-                                 overwrite = TRUE,
-                                 filename2 = "disturbanceMeta.csv") |> Cache(userTags = "prepInputsDistMeta")
+                                      destinationPath = inputPath(sim),
+                                      fun = "data.table::fread",
+                                      overwrite = TRUE,
+                                      filename2 = "disturbanceMeta.csv") |> Cache(userTags = "prepInputsDistMeta")
+  } else if (!is.null(sim$disturbanceMeta)) {
+    if(!all(c("eventID", "distName") %in% colnames(sim$disturbanceMeta))) {
+      stop("disturbanceMeta needs the columns eventID and distName")
+    }
   }
-  if(!all(c("eventID", "distName") %in% colnames(sim$disturbanceMeta))) {
-    stop("disturbanceMeta needs the columns eventID and distName")
-  }
-
+  
   if (!suppliedElsewhere("rstCurrentBurn", sim)) {
     sim$rstCurrentBurn <- sim$rasterToMatch
     sim$rstCurrentBurn[] <- NA

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -134,23 +134,30 @@ defineModule(sim, list(
                    "Columns are `pixelIndex`, `speciesCode`, `age`, `merch`, `foliage`, and `other`.")
     ),
     createsOutput(
-      objectName = "aboveGroundIncrements",
+      objectName = "growth_increments",
       objectClass = "data.table",
       desc = paste("Increments (metric tonnes of tree biomass/ha) in each pool",
                    "for each pixel and cohort. Gets updated at each timestep.",
-                   "Columns are `pixelIndex`, `speciesCode`, `age`, `merchInc`, `foliageInc`, and `otherInc`.")
+                   "Columns are `gcids`, `age`, `species_id` ,`sw_hW`,`merch_inc`, `foliage_inc`, and `other_inc`.")
+    ),
+    createsOutput(
+      objectName = "cohortDT",
+      objectClass = "data.table",
+      desc = paste("Cohort-level information.",
+                   "Columns are `cohortID`, `pixelIndex`, `age`, and `gcids`.")
     ),
     createsOutput(
       objectName = "disturbanceEvents",
       objectClass = "data.table",
       desc = paste("Table with disturbance events for each simulation year.",
-                   "Events types are defined in the 'disturbanceMeta' table.")
+                   "Events types are defined in the 'disturbanceMeta' table.",
+                   "Columns are `pixelIndex`, `year`, `eventID`.")
     ),
     createsOutput(
       objectName = "spatialDT",
       objectClass = "data.table",
       desc = paste("A data table with spatial information for the CBM spinup.",
-                   "Columns are `pixelIndex`, `gcid`, `ecozone`, `jurisdiction`, `standAge`.")
+                   "Columns are `pixelIndex`, `spatial_unit_id`.")
     ),
     createsOutput(
       objectName = "summaryAGB",
@@ -572,7 +579,7 @@ AnnualIncrements <- function(sim){
     )
     
     sim$growthIncrements <- setkey(annualIncrements, gcIndex)
-    sim$growthIncrements <- sim$growthIncrements[, .(gcIndex, speciesCode, age, cohortIndex, pixelIndex,merchInc, foliageInc, otherInc)]
+    sim$growthIncrements <- sim$growthIncrements[, .(gcIndex, speciesCode, age, cohortIndex, pixelIndex, merchInc, foliageInc, otherInc)]
   }
   return(invisible(sim))
 }

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -85,8 +85,12 @@ defineModule(sim, list(
       objectName = "rstCurrentBurn", objectClass = "SpatRaster",
       desc = "Raster of fires with 1 indicating burned pixels."
     ),
-    expectsInput("standAgeMap", "SpatRaster",
-                 desc =  paste("Stand age map in study area. Provided by Biomass_borealDataPrep.")),
+    expectsInput(
+      objectName = "standAgeMap", objectClass = "SpatRaster",
+      desc =  paste("Stand age map in study area. The default is for RIA, but",
+                    "should be provided by `Biomass_borealDataPrep`."),
+      sourceURL = NA
+    ),
     expectsInput(
       objectName = "studyArea", objectClass =  "sfc",
       desc = "Polygon to use as the study area; default is the RIA study area.", 

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -573,7 +573,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::rast",
       destinationPath = inputPath(sim),
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsRTM")
   }
   
   if (!suppliedElsewhere("masterRaster", sim)) {
@@ -590,7 +590,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::vect",
       destinationPath = inputPath(sim),
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsSA")
   }
   
   # pixel groups from vegetation data that gets updated annually
@@ -601,7 +601,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::rast",
       to = sim$rasterToMatch,
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsPGM")
   }
   
   if(inherits(sim$studyArea, "SpatVector")){
@@ -620,7 +620,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::vect",
       to = studyAreaBuffered,
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsEcozones")
     ez <- rasterize(ecozones, sim$rasterToMatch, field = "ECOZONE")
     sim$ecozones <- data.table(ecozone = as.integer(ez[]))
     sim$ecozones <- sim$ecozones[, pixelIndex := .I] |> na.omit()
@@ -639,7 +639,7 @@ AnnualDisturbances <- function(sim){
       fun = "terra::vect",
       to = studyAreaBuffered,
       overwrite = TRUE
-    ) |> Cache()
+    ) |> Cache(userTags = "prepInputsJurisdictions")
     juris_id <- rasterize(jurisdictions, sim$rasterToMatch, field = "PRUID")
     juris_id <- as.data.table(juris_id, na.rm = FALSE)
     juris_id$PRUID <- as.integer(as.character(juris_id$PRUID))
@@ -654,7 +654,7 @@ AnnualDisturbances <- function(sim){
                              fun = "data.table::fread",
                              destinationPath = inputPath(sim),
                              filename2 = "appendix2_table6_tb.csv",
-                             overwrite = TRUE) |> Cache()
+                             overwrite = TRUE) |> Cache(userTags = "prepInputsTable6")
   }
   
   if (!suppliedElsewhere("table7", sim)) {
@@ -662,7 +662,7 @@ AnnualDisturbances <- function(sim){
                              fun = "data.table::fread",
                              destinationPath = inputPath(sim),
                              filename2 = "appendix2_table7_tb.csv",
-                             overwrite = TRUE) |> Cache()
+                             overwrite = TRUE) |> Cache(userTags = "prepInputsTable7")
   }
   
   
@@ -674,7 +674,7 @@ AnnualDisturbances <- function(sim){
                                     fun = "data.table::fread",
                                     destinationPath = inputPath(sim),
                                     filename2 = "yieldTablesId.csv",
-                                    overwrite = TRUE) |> Cache()
+                                    overwrite = TRUE) |> Cache(userTags = "prepInputsYTId")
   }
   if(!all(c("gcid", "pixelIndex") %in% colnames(sim$yieldTablesId))) {
     stop("yieldTablesId needs the columns gcid and pixelIndex")
@@ -686,7 +686,7 @@ AnnualDisturbances <- function(sim){
                                   fun = "data.table::fread",
                                   destinationPath = inputPath(sim),
                                   filename2 = "yieldTablesCumulative.csv",
-                                  overwrite = TRUE) |> Cache()
+                                  overwrite = TRUE) |> Cache(userTags = "prepInputsYTC")
   }
   if(!all(c("gcid", "speciesCode", "biomass", "age") %in% colnames(sim$yieldTablesCumulative))) {
     stop("yieldTablesCumulative needs the columns gcid, age, biomass, and speciesCode")
@@ -699,7 +699,7 @@ AnnualDisturbances <- function(sim){
                                  destinationPath = inputPath(sim),
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
-                                 filename2 = "cohortData.csv") |> Cache()
+                                 filename2 = "cohortData.csv") |> Cache(userTags = "prepInputsCD")
   }
   if(!all(c("pixelGroup", "speciesCode", "B", "age") %in% colnames(sim$cohortData))) {
     stop("cohortData needs the columns pixelGroup, age, B, and speciesCode")
@@ -718,7 +718,7 @@ AnnualDisturbances <- function(sim){
                                  destinationPath = inputPath(sim),
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
-                                 filename2 = "disturbanceMeta.csv") |> Cache()
+                                 filename2 = "disturbanceMeta.csv") |> Cache(userTags = "prepInputsDistMeta")
   }
   if(!all(c("eventID", "distName") %in% colnames(sim$disturbanceMeta))) {
     stop("disturbanceMeta needs the columns eventID and distName")

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -54,7 +54,7 @@ defineModule(sim, list(
       desc = paste("Table defining the disturbance event types.", 
                    "This associates CBM-CFS3 disturbances with the",
                    "event IDs in the 'disturbanceEvents' table."),
-      sourceURL("TODO")
+      sourceURL("https://drive.google.com/file/d/11nIiLeRwgA7R7Lw685WIfb6HPGjM6kiB/view?usp=drive_link")
     ),
     expectsInput(
       objectName = "ecozones", objectClass = "data.table",
@@ -649,12 +649,14 @@ AnnualIncrements <- function(sim){
 
   #4. Cohort data. Information on biomass for each cohort and pixel group. Gets updated
   # annually.
-  if (!suppliedElsewhere("cohortData", sim))
+  if (!suppliedElsewhere("cohortData", sim)){
     sim$cohortData <- prepInputs(url = extractURL("cohortData"),
                                  destinationPath = inputPath(sim),
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
                                  filename2 = "cohortData.csv") |> Cache()
+  }
+
   
   # TODO will be used for plotting to keep the same colors of species as in LandR modules
   # if (!suppliedElsewhere("sppColorVect", sim)){
@@ -662,6 +664,20 @@ AnnualIncrements <- function(sim){
   #   sim$sppColorVect <- RColorBrewer::brewer.pal(n = length(sp), name = 'Accent')
   #   names(sim$sppColorVect) <- sp
   # }
+  
+  # 5. Disturbance meta
+  if (!suppliedElsewhere("disturbanceMeta", sim)) {
+    sim$cohortData <- prepInputs(url = extractURL("disturbanceMeta"),
+                                 destinationPath = inputPath(sim),
+                                 fun = "data.table::fread",
+                                 overwrite = TRUE,
+                                 filename2 = "disturbanceMeta.csv") |> Cache()
+  }
+
+  if (!suppliedElsewhere("rstCurrentBurn", sim)) {
+    sim$rstCurrentBurn <- sim$rasterToMatch
+    sim$rstCurrentBurn[] <- NA
+  }
   
   return(invisible(sim))
 }

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -50,6 +50,11 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1vwyp_i4rLncT2L1ukOvOI20DFxfYuni5/view?usp=drive_link" 
     ),
     expectsInput(
+      objectName = "cbmAdmin", objectClass = "data.frame",
+      desc = paste("Provides equivalent between provincial boundaries,",
+                   "CBM-id for provincial boundaries and CBM-spatial unit ids"),
+      sourceURL = "https://drive.google.com/file/d/1xdQt9JB5KRIw72uaN5m3iOk8e34t9dyz"),
+    expectsInput(
       objectName = "disturbanceMeta", objectClass = "data.table",
       desc = paste("Table defining the disturbance event types.", 
                    "This associates CBM-CFS3 disturbances with the",
@@ -138,7 +143,7 @@ defineModule(sim, list(
       objectClass = "data.table",
       desc = paste("Increments (metric tonnes of tree biomass/ha) in each pool",
                    "for each pixel and cohort. Gets updated at each timestep.",
-                   "Columns are `gcids`, `age`, `species_id` ,`sw_hW`,`merch_inc`, `foliage_inc`, and `other_inc`.")
+                   "Columns are `gcids`, `age`,`merch_inc`, `foliage_inc`, and `other_inc`.")
     ),
     createsOutput(
       objectName = "cohortDT",
@@ -146,6 +151,12 @@ defineModule(sim, list(
       desc = paste("Cohort-level information.",
                    "Columns are `cohortID`, `pixelIndex`, `age`, and `gcids`.")
     ),
+    createsOutput(
+      objectName = "gcMeta",
+      objectClass = "data.table",
+      desc = paste("Growth curve-level information.",
+                   "Columns are `gcids`, `species_id`, `speciesCode`, and `sw_hw`")
+    ),    
     createsOutput(
       objectName = "disturbanceEvents",
       objectClass = "data.table",
@@ -177,13 +188,6 @@ defineModule(sim, list(
       objectName = "yieldTablesId",
       objectClass = "data.table",
       desc = paste("A data.table linking spatially the `gcid`. Columns are `pixelIndex` and `gcid`.")
-    ),
-    createsOutput(
-      objectName = "yieldTablesIncrements",
-      objectClass = "data.table",
-      desc = paste("Yield tables divided into above ground pools and represented",
-                   "yearly increments. Columns are `gcid`, `age`, `speciesCode`,",
-                   "`merch`, `foliage`, `other`.")
     )
   )
 ))
@@ -545,7 +549,7 @@ AnnualIncrements <- function(sim){
                                              table7 = sim$table7,
                                              "pixelGroup")
   spatialDT[, pixelGroup := NULL]
-  sim$aboveGroundBiomass <- merge(spatialDT, cohortPools, by.x = "newPixelGroup", by.y = "pixelGroup")
+  sim$aboveGroundBiomass <- merge(spatialDT, cohortPools, by.x = "newPixelGroup", by.y = "pixelGroup", allow.cartesian = TRUE)
   sim$aboveGroundBiomass <- sim$aboveGroundBiomass[, .(pixelIndex, speciesCode, age, merch, foliage, other)]
   setorderv(sim$aboveGroundBiomass, c("pixelIndex", "speciesCode", "age"))
   

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -385,12 +385,14 @@ SplitYieldTables <- function(sim) {
   # We should get a number of gcid >= than the number before the spatial matching.
   sim$yieldTablesId <- spatialDT[, .(pixelIndex, gcid = newgcid)] 
   
+  sim$cohortDT <- generateCohortDT(sim$cohortData, sim$pixelGroupMap, sim$yieldTablesId)
+  
   # create spatialDT output
   standAge <- data.table(standAge = as.integer(sim$standAgeMap[]))
   standAge <- standAge[, pixelIndex := .I] |> na.omit()
   
   sim$spatialDT <- merge(
-    spatialDT[, .(pixelIndex, gcid = newgcid, ecozone, jurisdiction = PRUID)],
+    spatialDT[, .(pixelIndex, ecozone, jurisdiction = PRUID)],
     standAge
   )
   

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -391,10 +391,10 @@ SplitYieldTables <- function(sim) {
   sim$yieldTablesId <- spatialDT[, .(pixelIndex, yieldTableIndex = newytid)] 
   
   sim$cohortDT <- generateCohortDT(sim$cohortData, sim$pixelGroupMap, sim$yieldTablesId)
-  browser()
+
   # create standDT output
-  sim$standDT <- spatialDT[, .(pixelIndex, EcoBoundary = ecozone, AdminBoundaryID = PRUID)]
-  sim$standDT <- sim$standDT[cbmAdmin, on = "pixelIdex"]
+  sim$standDT <- spatialDT[, .(pixelIndex, EcoBoundaryID = ecozone, abreviation = juris_id)]
+  sim$standDT <- sim$cbmAdmin[sim$standDT, on = c("EcoBoundaryID", "abreviation")]
   sim$standDT <- sim$standDT[, .(pixelIndex, spatial_unit_id = SpatialUnitID)]
   
   spatialUnits <- unique(spatialDT[, pixelIndex := NULL])

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -46,19 +46,40 @@ defineModule(sim, list(
   inputObjects = bindrows(
     expectsInput(
       objectName = "cohortData", objectClass = "data.table",
-      desc = "Above ground biomass (g/m^2) of cohorts in pixel groups.",
+      desc = "Total above ground biomass (g/m^2) of each cohorts by pixel groups.",
+      columns = c(
+        speciesCode = "",
+        ecoregionGroup = "",
+        age = "",
+        B = "",
+        pixelGroup = "",
+        totalBiomass = ""
+      ),
       sourceURL = "https://drive.google.com/file/d/1vwyp_i4rLncT2L1ukOvOI20DFxfYuni5/view?usp=drive_link" 
     ),
     expectsInput(
-      objectName = "cbmAdmin", objectClass = "data.frame",
+      objectName = "cbmAdmin", objectClass = "data.table",
       desc = paste("Provides equivalent between provincial boundaries,",
                    "CBM-id for provincial boundaries and CBM-spatial unit ids"),
+      columns = c(
+        AdminBoundaryID = "",
+        stump_parameter_id = "",
+        adminName = "",
+        abreviation = "",
+        SpatialUnitID = "",
+        EcoBoundaryID = ""
+      ),
       sourceURL = "https://drive.google.com/file/d/1xdQt9JB5KRIw72uaN5m3iOk8e34t9dyz"),
     expectsInput(
       objectName = "disturbanceMeta", objectClass = "data.table",
       desc = paste("Table defining the disturbance event types.", 
                    "This associates CBM-CFS3 disturbances with the",
                    "event IDs in the 'disturbanceEvents' table."),
+      columns = c(
+        name = "",
+        eventID = "",
+        priority = ""
+      ),
       sourceURL = "https://drive.google.com/file/d/11nIiLeRwgA7R7Lw685WIfb6HPGjM6kiB/view?usp=drive_link"
     ),
     expectsInput(
@@ -66,6 +87,10 @@ defineModule(sim, list(
       desc = paste("A data.table with the ecozone for each pixelIndex. Used to determine",
                    "the equation parameters to split the above ground biomass into",
                    "carbon pools."),
+      columns = c(
+        pixelIndex = "",
+        ecozone = ""
+      ),
       sourceURL = "http://sis.agr.gc.ca/cansis/nsdb/ecostrat/zone/ecozone_shp.zip"
     ),
     expectsInput(
@@ -73,6 +98,11 @@ defineModule(sim, list(
       desc = paste("A data.table with the province/territory for each pixelIndex.", 
                    "Used to determine the equation parameters to split the above", 
                    "ground biomass into carbon pools."),
+      columns = c(
+        pixelIndex = "",
+        PRUID = "",
+        juris_id = ""
+      ),
       sourceURL = "https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/boundary-limites/files-fichiers/lpr_000a21a_e.zip"
     ),
     expectsInput(
@@ -114,11 +144,21 @@ defineModule(sim, list(
                    "Columns are `yieldTableIndex`, `age`, `speciesCode`, `biomass`. `yieldTableIndex` is the",
                    "growth curve identifier that depends on species combination.",
                    "`biomass` is the biomass for the given species at the pixel age."),
+      columns = c(
+        yieldTableIndex = "",
+        age = "",
+        speciesCode = "",
+        biomass = ""
+      ),
       sourceURL = "https://drive.google.com/file/d/1ePPc_a8u6K_Sefd_wVS3E9BiSqK9DOnO/view?usp=drive_link"
     ),
     expectsInput(
       objectName = "yieldTablesId", objectClass = "data.table",
       desc = paste("A data.table linking spatially the `yieldTableIndex`. Columns are `pixelIndex` and `yieldTableIndex`."),
+      columns = c(
+        pixelIndex = "",
+        yieldTableIndex = ""
+      ),
       sourceURL = "https://drive.google.com/file/d/1OExYMhxDvTWuShlRoCMeJEDW2PgSHofW/view?usp=drive_link"
     )
     # expectsInput("sppColorVect", "character",
@@ -133,24 +173,11 @@ defineModule(sim, list(
                    "Columns are `pixelIndex`, `speciesCode`, `age`, `merch`, `foliage`, and `other`.")
     ),
     createsOutput(
-      objectName = "growth_increments",
-      objectClass = "data.table",
-      desc = paste("Increments (metric tonnes of tree biomass/ha) in each pool",
-                   "for each pixel and cohort. Gets updated at each timestep.",
-                   "Columns are `gcids`, `age`,`merch_inc`, `foliage_inc`, and `other_inc`.")
-    ),
-    createsOutput(
       objectName = "cohortDT",
       objectClass = "data.table",
       desc = paste("Cohort-level information.",
                    "Columns are `cohortID`, `pixelIndex`, `age`, and `gcids`.")
     ),
-    createsOutput(
-      objectName = "gcMeta",
-      objectClass = "data.table",
-      desc = paste("Growth curve-level information.",
-                   "Columns are `gcids`, `species_id`, `speciesCode`, and `sw_hw`")
-    ),    
     createsOutput(
       objectName = "disturbanceEvents",
       objectClass = "data.table",
@@ -158,6 +185,19 @@ defineModule(sim, list(
                    "Events types are defined in the 'disturbanceMeta' table.",
                    "Columns are `pixelIndex`, `year`, `eventID`.")
     ),
+    createsOutput(
+      objectName = "growth_increments",
+      objectClass = "data.table",
+      desc = paste("Increments (metric tonnes of tree biomass/ha) in each pool",
+                   "for each pixel and cohort. Gets updated at each timestep.",
+                   "Columns are `gcids`, `age`,`merch_inc`, `foliage_inc`, and `other_inc`.")
+    ),
+    createsOutput(
+      objectName = "gcMeta",
+      objectClass = "data.table",
+      desc = paste("Growth curve-level information.",
+                   "Columns are `gcids`, `species_id`, `speciesCode`, and `sw_hw`")
+    ),    
     createsOutput(
       objectName = "standDT",
       objectClass = "data.table",

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -448,9 +448,11 @@ SplitYieldTables <- function(sim) {
   )
   
   # add the species code in canfi
-  allInfoYieldTables <- addCanfiCode(
-    cohortData = allInfoYieldTables
+  allInfoYieldTables <- addSpeciesCode(
+    cohortData = allInfoYieldTables,
+    code = "CanfiCode"
   )
+  setnames(allInfoYieldTables, old = "newCode", new = "canfi_species")
   
   ##############################################################################
   #2. START processing curves from AGB to 3 pools
@@ -574,9 +576,11 @@ AnnualIncrements <- function(sim){
   )
   
   # add the species code in canfi
-  allInfoCohortData <- addCanfiCode(
-    cohortData = allInfoCohortData
+  allInfoCohortData <- addSpeciesCode(
+    cohortData = allInfoCohortData,
+    code = "CanfiCode"
   )
+  setnames(allInfoCohortData, old = "newCode", new = "canfi_species")
   
   # convert m^2 into tonnes/ha
   allInfoCohortData$B <- allInfoCohortData$B/100

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -64,7 +64,7 @@ defineModule(sim, list(
       sourceURL = "http://sis.agr.gc.ca/cansis/nsdb/ecostrat/zone/ecozone_shp.zip"
     ),
     expectsInput(
-      objectName = "juridictions", objectClass = "data.table",
+      objectName = "jurisdictions", objectClass = "data.table",
       desc = paste("A data.table with the province/territory for each pixelIndex.", 
                    "Used to determine the equation parameters to split the above", 
                    "ground biomass into carbon pools."),
@@ -363,7 +363,7 @@ SplitYieldTables <- function(sim) {
   # Spatial Matching
   spatialDT <- spatialMatch(
     pixelGroupMap = sim$yieldTablesId,
-    juridictions = sim$juridictions,
+    jurisdictions = sim$jurisdictions,
     ecozones = sim$ecozones
   ) |> na.omit()
   
@@ -490,7 +490,7 @@ AnnualIncrements <- function(sim){
   # 3. split cohort data of current year
   spatialDT <- spatialMatch(
     pixelGroupMap = sim$pixelGroupMap,
-    juridictions = sim$juridictions,
+    jurisdictions = sim$jurisdictions,
     ecozones = sim$ecozones
   ) |> na.omit()
   
@@ -627,25 +627,25 @@ AnnualDisturbances <- function(sim){
     setcolorder(sim$ecozones, c("pixelIndex", "ecozone"))
   }
   
-  if (!suppliedElsewhere("juridictions", sim)) {
+  if (!suppliedElsewhere("jurisdictions", sim)) {
     dt <- data.table(
       PRUID = c(10, 11, 12, 13, 24, 35, 46, 47, 48, 59, 60, 61, 62),
       juris_id = c("NL", "PE", "NS", "NB", "QC", "ON", "MB", "SK", "AB", "BC", "YT", "NT", "NU")
     )
     
-    juridictions <- prepInputs(
-      url = extractURL("juridictions"),
+    jurisdictions <- prepInputs(
+      url = extractURL("jurisdictions"),
       destinationPath = inputPath(sim),
       fun = "terra::vect",
       to = studyAreaBuffered,
       overwrite = TRUE
     ) |> Cache()
-    juris_id <- rasterize(juridictions, sim$rasterToMatch, field = "PRUID")
+    juris_id <- rasterize(jurisdictions, sim$rasterToMatch, field = "PRUID")
     juris_id <- as.data.table(juris_id, na.rm = FALSE)
     juris_id$PRUID <- as.integer(as.character(juris_id$PRUID))
-    sim$juridictions <- dt[juris_id, on = "PRUID"]
-    sim$juridictions <- sim$juridictions[, pixelIndex := .I] |> na.omit()
-    setcolorder(sim$juridictions, c("pixelIndex", "PRUID", "juris_id"))
+    sim$jurisdictions <- dt[juris_id, on = "PRUID"]
+    sim$jurisdictions <- sim$jurisdictions[, pixelIndex := .I] |> na.omit()
+    setcolorder(sim$jurisdictions, c("pixelIndex", "PRUID", "juris_id"))
   }
   
   # 2. NFI params

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -451,7 +451,10 @@ SplitYieldTables <- function(sim) {
   yieldIncrements <- copy(sim$yieldTablesCumulative)
   yieldIncrements[, (incCols) := lapply(.SD, function(x) c(NA, diff(x))), .SDcols = poolCols,
                by = c("gcid", "speciesCode")]
-  sim$yieldTablesIncrements <- yieldIncrements[,.(gcid, speciesCode, age, merchInc, foliageInc, otherInc)]
+  browser()
+  sim$growthIncrements <- merge(yieldIncrements[,.(gcid, speciesCode, age, merchInc, foliageInc, otherInc)],
+                                unique(sim$cohortDT[, .(gcid, speciesCode, gcIndex)]))
+  setcolorder(sim$growthIncrements, c("gcIndex", "gcid", "speciesCode", "age"))
   
   return(invisible(sim))
 }

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -481,7 +481,7 @@ PlotYieldTablesPools <- function(sim){
   )
   
   # plot increments
-  plot_dt <- sim$yieldTablesIncrements[yieldTableIndex %in% pixGroupToPlot]
+  plot_dt <- sim$growthIncrements[yieldTableIndex %in% pixGroupToPlot]
   plot_dt <- melt(
     plot_dt, 
     id.vars = c("yieldTableIndex", "speciesCode", "age"),

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -215,12 +215,12 @@ defineModule(sim, list(
       objectName = "yieldTablesCumulative",
       objectClass = "data.table",
       desc = paste("Yield tables divided into above ground pools. Columns are",
-                   "`gcid`, `age`, `speciesCode`, `merch`, `foliage`, `other`.)")
+                   "`yieldTableIndex`, `age`, `speciesCode`, `merch`, `foliage`, `other`.)")
     ),
     createsOutput(
       objectName = "yieldTablesId",
       objectClass = "data.table",
-      desc = paste("A data.table linking spatially the `gcid`. Columns are `pixelIndex` and `gcid`.")
+      desc = paste("A data.table linking spatially the `gcid`. Columns are `pixelIndex` and `yieldTableIndex`.")
     )
   )
 ))

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -89,7 +89,7 @@ defineModule(sim, list(
       objectName = "standAgeMap", objectClass = "SpatRaster",
       desc =  paste("Stand age map in study area. The default is for RIA, but",
                     "should be provided by `Biomass_borealDataPrep`."),
-      sourceURL = NA
+      sourceURL = "https://drive.google.com/file/d/1CPh3zHMcQiuUe8usXYHXvt_3I9-SIG7F/view?usp=drive_link"
     ),
     expectsInput(
       objectName = "studyArea", objectClass =  "sfc",
@@ -371,7 +371,6 @@ SplitYieldTables <- function(sim) {
   # with the yieldTablesId and speciesCode. yieldTablesId gives us the location. 
   # Location let's us figure out which ecozone, and admin. The canfi_species have 
   # numbers which we need to match with the parameters.
-  browser()
   # Spatial Matching
   spatialDT <- spatialMatch(
     pixelGroupMap = sim$yieldTablesId,
@@ -417,7 +416,6 @@ SplitYieldTables <- function(sim) {
   
   # convert m^2 into tonnes/ha
   allInfoYieldTables$B <- allInfoYieldTables$B/100
-  
   cumPools <- CBMutils::cumPoolsCreateAGB(allInfoAGBin = allInfoYieldTables,
                                 table6 = sim$table6,
                                 table7 = sim$table7,
@@ -667,6 +665,17 @@ AnnualDisturbances <- function(sim){
     sim$jurisdictions <- dt[juris_id, on = "PRUID"]
     sim$jurisdictions <- sim$jurisdictions[, pixelIndex := .I] |> na.omit()
     setcolorder(sim$jurisdictions, c("pixelIndex", "PRUID", "juris_id"))
+  }
+  
+  # pixel groups from vegetation data that gets updated annually
+  if (!suppliedElsewhere("standAgeMap", sim)) {
+    sim$standAgeMap <- prepInputs(
+      url = extractURL("standAgeMap"),
+      destinationPath = inputPath(sim),
+      fun = "terra::rast",
+      to = sim$rasterToMatch,
+      overwrite = TRUE
+    ) |> Cache(userTags = "prepInputsSAM")
   }
   
   # 2. NFI params

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -769,5 +769,18 @@ AnnualDisturbances <- function(sim){
     sim$rstCurrentBurn[] <- NA
   }
   
+  # cbmAdmin: this is needed to match species and parameters. Boudewyn et al 2007
+  # abbreviation and cbm spatial units and ecoBoudnary id is provided with the
+  # adminName to avoid confusion.
+  if (!suppliedElsewhere("cbmAdmin", sim)) {
+    if (!suppliedElsewhere("cbmAdminURL", sim)) {
+      sim$cbmAdminURL <- extractURL("cbmAdmin")
+    }
+    sim$cbmAdmin <- prepInputs(url = sim$cbmAdminURL,
+                               targetFile = "cbmAdmin.csv",
+                               destinationPath = inputPath(sim),
+                               fun = fread)
+  }
+  
   return(invisible(sim))
 }

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -86,12 +86,6 @@ defineModule(sim, list(
       desc = "Raster of fires with 1 indicating burned pixels."
     ),
     expectsInput(
-      objectName = "standAgeMap", objectClass = "SpatRaster",
-      desc =  paste("Stand age map in study area. The default is for RIA, but",
-                    "should be provided by `Biomass_borealDataPrep`."),
-      sourceURL = NA
-    ),
-    expectsInput(
       objectName = "studyArea", objectClass =  "sfc",
       desc = "Polygon to use as the study area; default is the RIA study area.", 
       sourceURL = "https://drive.google.com/file/d/1M8jGAuq1wuavSb40c-s9HKyigCuTt9Rf/view?usp=drive_link"
@@ -147,12 +141,6 @@ defineModule(sim, list(
                    "Events types are defined in the 'disturbanceMeta' table.")
     ),
     createsOutput(
-      objectName = "spatialDT",
-      objectClass = "data.table",
-      desc = paste("A data table with spatial information for the CBM spinup.",
-                   "Columns are `pixelIndex`, `gcid`, `ecozone`, `jurisdiction`, `standAge`.")
-    ),
-    createsOutput(
       objectName = "summaryAGB",
       objectClass = "data.table",
       desc = paste("Sum of biomass and increments for each species and above ground", 
@@ -185,7 +173,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
   switch(
     eventType,
     init = {
-
+      
       # split yield tables into AGB pools
       sim <- SplitYieldTables(sim)
       
@@ -210,7 +198,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       }
     },
     plotYC = {
-
+      
       # plot the yield tables
       sim <- PlotYieldTables(sim)
       
@@ -347,7 +335,7 @@ PlotYieldTables <- function(sim){
     nPlots <- nPixGroups
   } 
   pixGroupToPlot <- sample(unique(sim$yieldTablesId$gcid), nPlots)
-
+  
   # dt for plotting.
   plot_dt <- sim$yieldTablesCumulative[gcid %in% pixGroupToPlot]
   plot_dt[, totB := merch + foliage + other]
@@ -360,7 +348,7 @@ PlotYieldTables <- function(sim){
         types = P(sim)$.plots,
         filename = paste("yieldCurves"),
         title = paste("Yield curves for", nPlots, "randomly selected pixel groups")
-        )
+  )
   return(invisible(sim))
 }
 
@@ -371,7 +359,7 @@ SplitYieldTables <- function(sim) {
   # with the yieldTablesId and speciesCode. yieldTablesId gives us the location. 
   # Location let's us figure out which ecozone, and admin. The canfi_species have 
   # numbers which we need to match with the parameters.
-  browser()
+  
   # Spatial Matching
   spatialDT <- spatialMatch(
     pixelGroupMap = sim$yieldTablesId,
@@ -385,15 +373,6 @@ SplitYieldTables <- function(sim) {
   # Update yieldTablesId. When a gcid cross a CBM spatial units, there is a bifurcation.
   # We should get a number of gcid >= than the number before the spatial matching.
   sim$yieldTablesId <- spatialDT[, .(pixelIndex, gcid = newgcid)] 
-  
-  # create spatialDT output
-  standAge <- data.table(standAge = as.integer(sim$standAgeMap[]))
-  standAge <- standAge[, pixelIndex := .I] |> na.omit()
-  
-  sim$spatialDT <- merge(
-    spatialDT[, .(pixelIndex, gcid = newgcid, ecozone, jurisdiction = PRUID)],
-    standAge
-  )
   
   spatialUnits <- unique(spatialDT[, pixelIndex := NULL])
   
@@ -419,9 +398,9 @@ SplitYieldTables <- function(sim) {
   allInfoYieldTables$B <- allInfoYieldTables$B/100
   
   cumPools <- CBMutils::cumPoolsCreateAGB(allInfoAGBin = allInfoYieldTables,
-                                table6 = sim$table6,
-                                table7 = sim$table7,
-                                pixGroupCol = "gcid")
+                                          table6 = sim$table6,
+                                          table7 = sim$table7,
+                                          pixGroupCol = "gcid")
   
   #TODO
   # MAKE SURE THE PROVIDED CURVES ARE ANNUAL (probably not needed for LandR
@@ -433,11 +412,11 @@ SplitYieldTables <- function(sim) {
   minAgeId <- cumPools[,.(minAge = max(0, min(age) - 1)), by = c("gcid", "speciesCode")]
   fill0s <- minAgeId[,.(age = seq(from = 0, to = minAge, by = 1)), by = c("gcid", "speciesCode")]
   add0s <- data.table(gcid = fill0s$gcid,
-                           speciesCode = fill0s$speciesCode,
-                           age = fill0s$age,
-                           merch = 0,
-                           foliage = 0,
-                           other = 0 )
+                      speciesCode = fill0s$speciesCode,
+                      age = fill0s$age,
+                      merch = 0,
+                      foliage = 0,
+                      other = 0 )
   
   sim$yieldTablesCumulative <- rbind(cumPools,add0s)
   setcolorder(sim$yieldTablesCumulative, c("gcid", "speciesCode", "age"))
@@ -450,7 +429,7 @@ SplitYieldTables <- function(sim) {
   # by one row and filling the first entry with NA.
   yieldIncrements <- copy(sim$yieldTablesCumulative)
   yieldIncrements[, (incCols) := lapply(.SD, function(x) c(NA, diff(x))), .SDcols = poolCols,
-               by = c("gcid", "speciesCode")]
+                  by = c("gcid", "speciesCode")]
   sim$yieldTablesIncrements <- yieldIncrements[,.(gcid, speciesCode, age, merchInc, foliageInc, otherInc)]
   
   return(invisible(sim))
@@ -493,9 +472,9 @@ PlotYieldTablesPools <- function(sim){
         types = P(sim)$.plots,
         filename = "yieldCurveIncrements",
         title = "Increments merch fol other by species and pixel groups"
-        )
-    message(crayon::red("User: please inspect figures of the raw translation of your increments in: ",
-                        figurePath(sim)))
+  )
+  message(crayon::red("User: please inspect figures of the raw translation of your increments in: ",
+                      figurePath(sim)))
   
   return(invisible(sim))
 }
@@ -530,9 +509,9 @@ AnnualIncrements <- function(sim){
   # convert m^2 into tonnes/ha
   allInfoCohortData$B <- allInfoCohortData$B/100
   cohortPools <- CBMutils::cumPoolsCreateAGB(allInfoAGBin = allInfoCohortData,
-                                       table6 = sim$table6,
-                                       table7 = sim$table7,
-                                       "pixelGroup")
+                                             table6 = sim$table6,
+                                             table7 = sim$table7,
+                                             "pixelGroup")
   spatialDT[, pixelGroup := NULL]
   sim$aboveGroundBiomass <- merge(spatialDT, cohortPools, by.x = "newPixelGroup", by.y = "pixelGroup")
   sim$aboveGroundBiomass <- sim$aboveGroundBiomass[, .(pixelIndex, speciesCode, age, merch, foliage, other)]
@@ -555,11 +534,11 @@ AnnualIncrements <- function(sim){
                             otherInc = other - otherTminus1)]
     
     sim$aboveGroundIncrements <- annualIncrements[,.(pixelIndex, 
-                                                speciesCode,
-                                                age = age, 
-                                                merchInc, 
-                                                foliageInc, 
-                                                otherInc)]    
+                                                     speciesCode,
+                                                     age = age, 
+                                                     merchInc, 
+                                                     foliageInc, 
+                                                     otherInc)]    
   }
   return(invisible(sim))
 }
@@ -632,7 +611,7 @@ AnnualDisturbances <- function(sim){
   } else {
     stop("studyArea needs to be a SpatVector or a sf polygon")
   }
-
+  
   # ecozones
   if (!suppliedElsewhere("ecozones", sim)) {
     ecozones <- prepInputs(
@@ -669,18 +648,6 @@ AnnualDisturbances <- function(sim){
     setcolorder(sim$jurisdictions, c("pixelIndex", "PRUID", "juris_id"))
   }
   
-  # Stand Age
-  if (!suppliedElsewhere("standAgeMap", sim)) {
-    sim$pixelGroupMap <- prepInputs(
-      url = extractURL("standAgeMap"),
-      destinationPath = inputPath(sim),
-      fun = "terra::rast",
-      to = sim$rasterToMatch,
-      overwrite = TRUE
-    ) |> Cache(userTags = "prepInputsSAM")
-  }
-  
-  
   # 2. NFI params
   if (!suppliedElsewhere("table6", sim)) {
     sim$table6 <- prepInputs(url = extractURL("table6"),
@@ -708,21 +675,24 @@ AnnualDisturbances <- function(sim){
                                     destinationPath = inputPath(sim),
                                     filename2 = "yieldTablesId.csv",
                                     overwrite = TRUE) |> Cache(userTags = "prepInputsYTId")
+  } else if (!is.null(sim$yieldTablesId)) {
+    if(!all(c("gcid", "pixelIndex") %in% colnames(sim$yieldTablesId))) {
+      stop("yieldTablesId needs the columns gcid and pixelIndex")
+    }
   }
-  if(!all(c("gcid", "pixelIndex") %in% colnames(sim$yieldTablesId))) {
-    stop("yieldTablesId needs the columns gcid and pixelIndex")
-  }
+  
   
   # actual yield curves
   if (!suppliedElsewhere("yieldTablesCumulative", sim)) {
     sim$yieldTablesCumulative <- prepInputs(url = extractURL("yieldTablesCumulative"),
-                                  fun = "data.table::fread",
-                                  destinationPath = inputPath(sim),
-                                  filename2 = "yieldTablesCumulative.csv",
-                                  overwrite = TRUE) |> Cache(userTags = "prepInputsYTC")
-  }
-  if(!all(c("gcid", "speciesCode", "biomass", "age") %in% colnames(sim$yieldTablesCumulative))) {
-    stop("yieldTablesCumulative needs the columns gcid, age, biomass, and speciesCode")
+                                            fun = "data.table::fread",
+                                            destinationPath = inputPath(sim),
+                                            filename2 = "yieldTablesCumulative.csv",
+                                            overwrite = TRUE) |> Cache(userTags = "prepInputsYTC")
+  } else if (!is.null(sim$yieldTablesCumulative)) {
+    if(!all(c("gcid", "speciesCode", "biomass", "age") %in% colnames(sim$yieldTablesCumulative))){
+      stop("yieldTablesCumulative needs the columns gcid, age, biomass, and speciesCode")
+    }
   }
   
   #4. Cohort data. Information on biomass for each cohort and pixel group. Gets updated
@@ -733,9 +703,10 @@ AnnualDisturbances <- function(sim){
                                  fun = "data.table::fread",
                                  overwrite = TRUE,
                                  filename2 = "cohortData.csv") |> Cache(userTags = "prepInputsCD")
-  }
-  if(!all(c("pixelGroup", "speciesCode", "B", "age") %in% colnames(sim$cohortData))) {
-    stop("cohortData needs the columns pixelGroup, age, B, and speciesCode")
+  } else if (!is.null(sim$cohortData)) {
+    if(!all(c("pixelGroup", "speciesCode", "B", "age") %in% colnames(sim$cohortData))){
+      stop("cohortData needs the columns pixelGroup, age, B, and speciesCode")
+    }
   }
   
   # TODO will be used for plotting to keep the same colors of species as in LandR modules
@@ -748,15 +719,16 @@ AnnualDisturbances <- function(sim){
   # 5. Disturbance meta
   if (!suppliedElsewhere("disturbanceMeta", sim)) {
     sim$disturbanceMeta <- prepInputs(url = extractURL("disturbanceMeta"),
-                                 destinationPath = inputPath(sim),
-                                 fun = "data.table::fread",
-                                 overwrite = TRUE,
-                                 filename2 = "disturbanceMeta.csv") |> Cache(userTags = "prepInputsDistMeta")
+                                      destinationPath = inputPath(sim),
+                                      fun = "data.table::fread",
+                                      overwrite = TRUE,
+                                      filename2 = "disturbanceMeta.csv") |> Cache(userTags = "prepInputsDistMeta")
+  } else if (!is.null(sim$disturbanceMeta)) {
+    if(!all(c("eventID", "distName") %in% colnames(sim$disturbanceMeta))) {
+      stop("disturbanceMeta needs the columns eventID and distName")
+    }
   }
-  if(!all(c("eventID", "distName") %in% colnames(sim$disturbanceMeta))) {
-    stop("disturbanceMeta needs the columns eventID and distName")
-  }
-
+  
   if (!suppliedElsewhere("rstCurrentBurn", sim)) {
     sim$rstCurrentBurn <- sim$rasterToMatch
     sim$rstCurrentBurn[] <- NA

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -8,8 +8,13 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
   cohortDT <- addCanfiCode(cohortDT)
   setorder(cohortDT, pixelIndex, speciesCode, age)
   cohortDT[, cohortIndex := .I]
-  cohortDT <- merge(cohortDT, yieldTablesId, by = "pixelIndex")
+  if (!is.null(yieldTablesId)){
+    cohortDT <- merge(cohortDT, yieldTablesId, by = "pixelIndex")
+    cohortDT[, gcIndex := .GRP, by = .(yieldTableIndex, speciesCode)]
+    cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex, yieldTableIndex)]
+  } else {
+    cohortDT[, gcIndex := .GRP, by = .(pixelIndex, speciesCode, age)]
+    cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex)]
+  }
   setkey(cohortDT, cohortIndex)
-  cohortDT[, gcIndex := .GRP, by = .(yieldTableIndex, speciesCode)]
-  cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex, yieldTableIndex)]
 }

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -4,7 +4,8 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
   ) 
   cohortDT <- cohortDT[, pixelIndex := .I] |> na.omit()
   cohortDT <- merge(cohortDT,
-                    cohortData[,.(speciesCode, age, pixelGroup)])
+                    cohortData[,.(speciesCode, age, pixelGroup)],
+                    allow.cartesian = TRUE)
   cohortDT <- addCanfiCode(cohortDT)
   setorder(cohortDT, pixelIndex, speciesCode, age)
   cohortDT[, cohortIndex := .I]

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -7,15 +7,16 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
                     cohortData[,.(speciesCode, age, pixelGroup)],
                     allow.cartesian = TRUE)
   cohortDT <- addCanfiCode(cohortDT)
+  cohortDT <- addForestType(cohortDT)
   setorder(cohortDT, pixelIndex, speciesCode, age)
-  cohortDT[, cohortIndex := .I]
+  cohortDT[, cohortID := .I]
   if (!is.null(yieldTablesId)){
     cohortDT <- merge(cohortDT, yieldTablesId, by = "pixelIndex")
-    cohortDT[, gcIndex := .GRP, by = .(yieldTableIndex, speciesCode)]
-    cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex, yieldTableIndex)]
+    cohortDT[, gcids := .GRP, by = .(yieldTableIndex, speciesCode)]
+    cohortDT <- cohortDT[,.(cohortID, pixelIndex, speciesCode, species_id = canfi_species, age, gcids, yieldTableIndex, sw_hw)]
   } else {
-    cohortDT[, gcIndex := .GRP, by = .(pixelIndex, speciesCode, age)]
-    cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex)]
+    cohortDT[, gcids := .GRP, by = .(pixelIndex, speciesCode, age)]
+    cohortDT <- cohortDT[,.(cohortID, pixelIndex, speciesCode, species_id = canfi_species, age, gcids, sw_hw)]
   }
-  setkey(cohortDT, cohortIndex)
+  setkey(cohortDT, cohortID)
 }

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -1,5 +1,4 @@
 generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
-  browser()
   cohortDT <- data.table(
     pixelGroup = as.integer(pixelGroupMap[])
   ) 

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -6,17 +6,17 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
   cohortDT <- merge(cohortDT,
                     cohortData[,.(speciesCode, age, pixelGroup)],
                     allow.cartesian = TRUE)
-  cohortDT <- addCanfiCode(cohortDT)
+  cohortDT <- addSpeciesCode(cohortDT, CBM_speciesID)
   cohortDT <- addForestType(cohortDT)
   setorder(cohortDT, pixelIndex, speciesCode, age)
   cohortDT[, cohortID := .I]
   if (!is.null(yieldTablesId)){
     cohortDT <- merge(cohortDT, yieldTablesId, by = "pixelIndex")
     cohortDT[, gcids := .GRP, by = .(yieldTableIndex, speciesCode)]
-    cohortDT <- cohortDT[,.(cohortID, pixelIndex, speciesCode, species_id = canfi_species, age, gcids, yieldTableIndex, sw_hw)]
+    cohortDT <- cohortDT[,.(cohortID, pixelIndex, speciesCode, species_id = newCode, age, gcids, yieldTableIndex, sw_hw)]
   } else {
     cohortDT[, gcids := .GRP, by = .(pixelIndex, speciesCode, age)]
-    cohortDT <- cohortDT[,.(cohortID, pixelIndex, speciesCode, species_id = canfi_species, age, gcids, sw_hw)]
+    cohortDT <- cohortDT[,.(cohortID, pixelIndex, speciesCode, species_id = newCode, age, gcids, sw_hw)]
   }
   setkey(cohortDT, cohortID)
 }

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -10,6 +10,6 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
   cohortDT[, cohortIndex := .I]
   cohortDT <- merge(cohortDT, yieldTablesId, by = "pixelIndex")
   setkey(cohortDT, cohortIndex)
-  cohortDT[, gcIndex := .GRP, by = .(gcid, speciesCode)]
-  cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex, gcid)]
+  cohortDT[, gcIndex := .GRP, by = .(yieldTableIndex, speciesCode)]
+  cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex, yieldTableIndex)]
 }

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -1,0 +1,16 @@
+generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
+  browser()
+  cohortDT <- data.table(
+    pixelGroup = as.integer(pixelGroupMap[])
+  ) 
+  cohortDT <- cohortDT[, pixelIndex := .I] |> na.omit()
+  cohortDT <- merge(cohortDT,
+                    cohortData[,.(speciesCode, age, pixelGroup)])
+  cohortDT <- addCanfiCode(cohortDT)
+  setorder(cohortDT, pixelIndex, speciesCode, age)
+  cohortDT[, cohortIndex := .I]
+  cohortDT <- merge(cohortDT, yieldTablesId, by = "pixelIndex")
+  setkey(cohortDT, cohortIndex)
+  cohortDT[, gcIndex := .GRP, by = .(gcid, speciesCode)]
+  cohortDT <- cohortDT[,.(cohortIndex, pixelIndex, speciesCode, canfiCode = canfi_species, age, gcIndex, gcid)]
+}

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -6,7 +6,7 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
   cohortDT <- merge(cohortDT,
                     cohortData[,.(speciesCode, age, pixelGroup)],
                     allow.cartesian = TRUE)
-  cohortDT <- addSpeciesCode(cohortDT, CBM_speciesID)
+  cohortDT <- addSpeciesCode(cohortDT, code = "CBM_speciesID")
   cohortDT <- addForestType(cohortDT)
   setorder(cohortDT, pixelIndex, speciesCode, age)
   cohortDT[, cohortID := .I]

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -53,7 +53,7 @@ addSpeciesCode <- function(cohortData, code = "CanfiCode"){
     stop("The code argument needs to be a column in the data.table LandR::sppEquivalencies_CA")
   }
   speciesCode <- unique(cohortData$speciesCode)
-  newCode <- LandR::sppEquivalencies_CA[match(speciesCode, LandR), code]
+  newCode <- LandR::sppEquivalencies_CA[match(speciesCode, LandR), get(code)]
   
   if(any(is.na(newCode))) {
     missing_species <- speciesCode[which(is.na(newCode))]

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -1,27 +1,27 @@
 spatialMatch <- function(pixelGroupMap, juridictions, ecozones){
   if(is.data.table(pixelGroupMap)) {
-    if(all(c("pixelId", "gcid") %in% names(pixelGroupMap))) {
+    if(all(c("pixelIndex", "gcid") %in% names(pixelGroupMap))) {
       spatialMatch <- pixelGroupMap
     } else {
-      stop("The data table pixelGroupMap need to have the column `pixelId`and `gcid`")
+      stop("The data table pixelGroupMap need to have the column `pixelIndex`and `gcid`")
     }
   } else if (inherits(pixelGroupMap, "SpatRaster")) {
     spatialMatch <- data.table(
       pixelGroup = as.integer(pixelGroupMap[])
     ) 
-    spatialMatch <- spatialMatch[, pixelId := .I] |> na.omit()
+    spatialMatch <- spatialMatch[, pixelIndex := .I] |> na.omit()
   } else {
     stop("The object pixelGroupMap needs to be a data.table or a SpatRaster")
   }
-  if (any(!(spatialMatch$pixelId %in% ecozones$pixelId))) {
+  if (any(!(spatialMatch$pixelIndex %in% ecozones$pixelIndex))) {
     stop("There is a problem: some pixels cannot be matched to an ecozone...")
   }
-  spatialMatch <- spatialMatch[ecozones, on = "pixelId"]
+  spatialMatch <- spatialMatch[ecozones, on = "pixelIndex"]
   
-  if (any(!(spatialMatch$pixelId %in% juridictions$pixelId))) {
+  if (any(!(spatialMatch$pixelIndex %in% juridictions$pixelIndex))) {
     stop("There is a problem: some pixels cannot be matched to a juridiction...")
   }
-  spatialMatch <- spatialMatch[juridictions, on = "pixelId"]
+  spatialMatch <- spatialMatch[juridictions, on = "pixelIndex"]
   return(spatialMatch)
 }
 

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -66,6 +66,7 @@ addCanfiCode <- function(cohortData){
 addForestType <- function(cohortData){
   speciesCode <- unique(cohortData$speciesCode)
   sw_hw <- LandR::sppEquivalencies_CA[match(speciesCode, LandR), Broadleaf]
+  sw_hw <- ifelse(sw_hw, "hw", "sw")
   
   if(any(is.na(sw_hw))) {
     missing_species <- speciesCode[which(is.na(sw_hw))]

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -48,18 +48,21 @@ addSpatialUnits <- function(cohortData, spatialUnits) {
   return(allInfoCohortData)
 }
 
-addCanfiCode <- function(cohortData){
+addSpeciesCode <- function(cohortData, code = "CanfiCode"){
+  if(!(code %in% colnames(LandR::sppEquivalencies_CA))){
+    stop("The code argument needs to be a column in the data.table LandR::sppEquivalencies_CA")
+  }
   speciesCode <- unique(cohortData$speciesCode)
-  canfi_species <- LandR::sppEquivalencies_CA[match(speciesCode, LandR), CanfiCode]
+  newCode <- LandR::sppEquivalencies_CA[match(speciesCode, LandR), code]
   
-  if(any(is.na(canfi_species))) {
-    missing_species <- speciesCode[which(is.na(canfi_species))]
+  if(any(is.na(newCode))) {
+    missing_species <- speciesCode[which(is.na(newCode))]
     stop("no species match found for in Boudewyn tables: ", paste(missing_species, collapse = ", "))
   }
   
-  sp_canfi <- data.table(speciesCode = speciesCode,
-                         canfi_species = canfi_species)
-  allCohortInfo <- merge(cohortData, sp_canfi, by = "speciesCode")
+  sp_code <- data.table(speciesCode = speciesCode,
+                        newCode = newCode)
+  allCohortInfo <- merge(cohortData, sp_code, by = "speciesCode")
   return(allCohortInfo)
 }
 

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -1,4 +1,4 @@
-spatialMatch <- function(pixelGroupMap, juridictions, ecozones){
+spatialMatch <- function(pixelGroupMap, jurisdictions, ecozones){
   if(is.data.table(pixelGroupMap)) {
     if(all(c("pixelIndex", "gcid") %in% names(pixelGroupMap))) {
       spatialMatch <- pixelGroupMap
@@ -18,10 +18,10 @@ spatialMatch <- function(pixelGroupMap, juridictions, ecozones){
   }
   spatialMatch <- spatialMatch[ecozones, on = "pixelIndex"]
   
-  if (any(!(spatialMatch$pixelIndex %in% juridictions$pixelIndex))) {
-    stop("There is a problem: some pixels cannot be matched to a juridiction...")
+  if (any(!(spatialMatch$pixelIndex %in% jurisdictions$pixelIndex))) {
+    stop("There is a problem: some pixels cannot be matched to a jurisdiction...")
   }
-  spatialMatch <- spatialMatch[juridictions, on = "pixelIndex"]
+  spatialMatch <- spatialMatch[jurisdictions, on = "pixelIndex"]
   return(spatialMatch)
 }
 

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -62,3 +62,18 @@ addCanfiCode <- function(cohortData){
   allCohortInfo <- merge(cohortData, sp_canfi, by = "speciesCode")
   return(allCohortInfo)
 }
+
+addForestType <- function(cohortData){
+  speciesCode <- unique(cohortData$speciesCode)
+  sw_hw <- LandR::sppEquivalencies_CA[match(speciesCode, LandR), Broadleaf]
+  
+  if(any(is.na(sw_hw))) {
+    missing_species <- speciesCode[which(is.na(sw_hw))]
+    stop("no species match found for in Boudewyn tables: ", paste(missing_species, collapse = ", "))
+  }
+  
+  refTable <- data.table(speciesCode = speciesCode,
+                         sw_hw = sw_hw)
+  allCohortInfo <- merge(cohortData, refTable, by = "speciesCode")
+  return(allCohortInfo)
+}

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -1,9 +1,9 @@
 spatialMatch <- function(pixelGroupMap, jurisdictions, ecozones){
   if(is.data.table(pixelGroupMap)) {
-    if(all(c("pixelIndex", "gcid") %in% names(pixelGroupMap))) {
+    if(all(c("pixelIndex", "yieldTableIndex") %in% names(pixelGroupMap))) {
       spatialMatch <- pixelGroupMap
     } else {
-      stop("The data table pixelGroupMap need to have the column `pixelIndex`and `gcid`")
+      stop("The data table pixelGroupMap need to have the column `pixelIndex`and `yieldTableIndex`")
     }
   } else if (inherits(pixelGroupMap, "SpatRaster")) {
     spatialMatch <- data.table(
@@ -26,13 +26,13 @@ spatialMatch <- function(pixelGroupMap, jurisdictions, ecozones){
 }
 
 addSpatialUnits <- function(cohortData, spatialUnits) {
-  if ("gcid" %in% names(spatialUnits)) {
-    if("gcid" %in% names(cohortData)){
-      allInfoCohortData <- merge(cohortData, spatialUnits, by = "gcid", allow.cartesian = TRUE)
-      allInfoCohortData[, gcid := NULL]
-      setnames(allInfoCohortData, old = "newgcid", new = "gcid")
+  if ("yieldTableIndex" %in% names(spatialUnits)) {
+    if("yieldTableIndex" %in% names(cohortData)){
+      allInfoCohortData <- merge(cohortData, spatialUnits, by = "yieldTableIndex", allow.cartesian = TRUE)
+      allInfoCohortData[, yieldTableIndex := NULL]
+      setnames(allInfoCohortData, old = "newytid", new = "yieldTableIndex")
     } else {
-      stop("The object cohortData need the column gcid")
+      stop("The object cohortData need the column yieldTableIndex")
     }
   } else if ("pixelGroup" %in% colnames(spatialUnits)) {
     if("pixelGroup" %in% names(cohortData)){
@@ -43,7 +43,7 @@ addSpatialUnits <- function(cohortData, spatialUnits) {
       stop("The object cohortData need the column pixelGroup")
     }
   } else {
-    stop("The object spatialUnits need the column pixelGroup OR gcid")
+    stop("The object spatialUnits need the column pixelGroup OR yieldTableIndex")
   }
   return(allInfoCohortData)
 }

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -36,7 +36,7 @@ gg_speciessummary <- function(x) {
 gg_yieldCurves <- function(x, title){
   ggplot(x, aes(age, totB, color = speciesCode)) + geom_line() + theme_bw() +
     #scale_color_manual(values = colors) +
-    facet_wrap(~gcid) +
+    facet_wrap(~yieldTableIndex) +
     labs(title = title, x = "Age", y = 'AGB (tonnes/ha)', color = "Species") +
     theme_bw()
 }
@@ -46,7 +46,7 @@ gg_yieldCurvesPools <- function(x, title) {
     geom_area(position = position_stack()) +
     #scale_fill_manual(values = colors) +
     theme_bw() +
-    facet_grid(gcid ~ pool) +
+    facet_grid(yieldTableIndex ~ pool) +
     ggtitle(title) +
     theme(panel.background = element_rect(fill = "white", color = NA),
           panel.grid = element_blank())

--- a/tests/testthat/test-1-matchCurveToCohort.R
+++ b/tests/testthat/test-1-matchCurveToCohort.R
@@ -3,18 +3,18 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   # test spatialMatch with pixelGroupDT
   set.seed(1)
   nonforested <- sample(c(1:9), 3)
-  pixelGroup <- data.table(pixelId = c(1:9),
+  pixelGroup <- data.table(pixelIndex = c(1:9),
                            gcid = c(rep(1,3), rep(2,3), rep(3,3)))
   pixelGroup <- pixelGroup[-nonforested,]
   
-  juridictions <- data.table(pixelId = c(1:9),
+  juridictions <- data.table(pixelIndex = c(1:9),
                              juridiction = c(rep("a", 5), rep("b", 4)))
-  ecozones <- data.table(pixelId = c(1:9),
+  ecozones <- data.table(pixelIndex = c(1:9),
                          ecozone = c(rep(1, 2), rep(2, 5), rep(1, 2)))
   out1 <- spatialMatch(pixelGroup, juridictions, ecozones)
   
   expect_is(out1, "data.table")
-  expect_named(out1, c("pixelId", "gcid", "ecozone", "juridiction"))
+  expect_named(out1, c("pixelIndex", "gcid", "ecozone", "juridiction"))
   expect_equal(out1$ecozone, ecozones$ecozone)
   expect_equal(out1$juridiction, juridictions$juridiction)
   expect_true(all(is.na(out1$gcid[nonforested])))
@@ -26,7 +26,7 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   pixelGroupMap[nonforested] <- NA
   out2 <- spatialMatch(pixelGroupMap, juridictions, ecozones)
   expect_is(out2, "data.table")
-  expect_named(out2, c("pixelId", "pixelGroup", "ecozone", "juridiction"), ignore.order = T)
+  expect_named(out2, c("pixelIndex", "pixelGroup", "ecozone", "juridiction"), ignore.order = T)
   expect_equal(out2$ecozone, ecozones$ecozone)
   expect_equal(out2$juridiction, juridictions$juridiction)
   expect_true(all(is.na(out2$gcid[nonforested])))
@@ -34,7 +34,7 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   # test addSpatialUnits with yield tables
   spatialUnits <- na.omit(out1)
   spatialUnits[, newgcid := .GRP, by = .(gcid, ecozone, juridiction)]
-  spatialUnits <- unique(spatialUnits[, pixelId := NULL])
+  spatialUnits <- unique(spatialUnits[, pixelIndex := NULL])
   LandR_species = c("Abie_las", "Betu_pap", "Pice_gla")
   yieldTables <- data.table(
     expand.grid(speciesCode = LandR_species, 

--- a/tests/testthat/test-1-matchCurveToCohort.R
+++ b/tests/testthat/test-1-matchCurveToCohort.R
@@ -7,16 +7,16 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
                            gcid = c(rep(1,3), rep(2,3), rep(3,3)))
   pixelGroup <- pixelGroup[-nonforested,]
   
-  juridictions <- data.table(pixelIndex = c(1:9),
-                             juridiction = c(rep("a", 5), rep("b", 4)))
+  jurisdictions <- data.table(pixelIndex = c(1:9),
+                             jurisdiction = c(rep("a", 5), rep("b", 4)))
   ecozones <- data.table(pixelIndex = c(1:9),
                          ecozone = c(rep(1, 2), rep(2, 5), rep(1, 2)))
-  out1 <- spatialMatch(pixelGroup, juridictions, ecozones)
+  out1 <- spatialMatch(pixelGroup, jurisdictions, ecozones)
   
   expect_is(out1, "data.table")
-  expect_named(out1, c("pixelIndex", "gcid", "ecozone", "juridiction"))
+  expect_named(out1, c("pixelIndex", "gcid", "ecozone", "jurisdiction"))
   expect_equal(out1$ecozone, ecozones$ecozone)
-  expect_equal(out1$juridiction, juridictions$juridiction)
+  expect_equal(out1$jurisdiction, jurisdictions$jurisdiction)
   expect_true(all(is.na(out1$gcid[nonforested])))
 
     # test spatialMatch with spatRast
@@ -24,16 +24,16 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
     matrix(data = c(rep(1,3), rep(2, 3), rep(3, 3)), nrow = 3, ncol = 3)
   )
   pixelGroupMap[nonforested] <- NA
-  out2 <- spatialMatch(pixelGroupMap, juridictions, ecozones)
+  out2 <- spatialMatch(pixelGroupMap, jurisdictions, ecozones)
   expect_is(out2, "data.table")
-  expect_named(out2, c("pixelIndex", "pixelGroup", "ecozone", "juridiction"), ignore.order = T)
+  expect_named(out2, c("pixelIndex", "pixelGroup", "ecozone", "jurisdiction"), ignore.order = T)
   expect_equal(out2$ecozone, ecozones$ecozone)
-  expect_equal(out2$juridiction, juridictions$juridiction)
+  expect_equal(out2$jurisdiction, jurisdictions$jurisdiction)
   expect_true(all(is.na(out2$gcid[nonforested])))
   
   # test addSpatialUnits with yield tables
   spatialUnits <- na.omit(out1)
-  spatialUnits[, newgcid := .GRP, by = .(gcid, ecozone, juridiction)]
+  spatialUnits[, newgcid := .GRP, by = .(gcid, ecozone, jurisdiction)]
   spatialUnits <- unique(spatialUnits[, pixelIndex := NULL])
   LandR_species = c("Abie_las", "Betu_pap", "Pice_gla")
   yieldTables <- data.table(
@@ -44,7 +44,7 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   
   expect_true(all(LandR_species %in% out3$speciesCode))
   expect_equal(nrow(out3), 15)
-  expect_named(out3, c("gcid", "speciesCode", "ecozone", "juridiction"), ignore.order = TRUE)
+  expect_named(out3, c("gcid", "speciesCode", "ecozone", "jurisdiction"), ignore.order = TRUE)
 
   # test with cohortData
   cohortData <- data.table(
@@ -56,12 +56,12 @@ test_that("functions to match AGB with CBM spatial units and canfi species work"
   
   expect_true(all(LandR_species %in% out4$speciesCode))
   expect_equal(nrow(out4), 15)
-  expect_named(out4, c("pixelGroup", "speciesCode", "ecozone", "juridiction"), ignore.order = TRUE)
+  expect_named(out4, c("pixelGroup", "speciesCode", "ecozone", "jurisdiction"), ignore.order = TRUE)
   
   # test add CanfiCode
   out5 <- addCanfiCode(out3)
   expect_equal(nrow(out5), nrow(out3))
-  expect_named(out5, c("speciesCode", "ecozone", "juridiction", "gcid", "canfi_species"), ignore.order = TRUE)
+  expect_named(out5, c("speciesCode", "ecozone", "jurisdiction", "gcid", "canfi_species"), ignore.order = TRUE)
   expect_true(all(out5$canfi_species[out5$speciesCode == "Abie_las"] == 304))
   expect_true(all(out5$canfi_species[out5$speciesCode == "Betu_pap"] == 1303))
   expect_true(all(out5$canfi_species[out5$speciesCode == "Pice_gla"] == 105))

--- a/tests/testthat/test-2-LandRCBM_split3pools.R
+++ b/tests/testthat/test-2-LandRCBM_split3pools.R
@@ -16,7 +16,7 @@ test_that("module runs with small example", {
                               destinationPath = spadesTestPaths$temp$inputs,
                               filename2 = "yieldTablesId.csv",
                               overwrite = TRUE)
-  yieldTablesId$pixelId[c(1:ncell(rtm))] <- c(1:ncell(rtm))
+  yieldTablesId$pixelIndex[c(1:ncell(rtm))] <- c(1:ncell(rtm))
   yieldTablesId <- yieldTablesId[c(1:ncell(rtm)), ]
   
   yieldTablesCumulative <- prepInputs(url = "https://drive.google.com/file/d/1ePPc_a8u6K_Sefd_wVS3E9BiSqK9DOnO/view?usp=drive_link",
@@ -74,8 +74,8 @@ test_that("module runs with small example", {
   
   # check yieldTablesId
   expect_is(simTest$yieldTablesId, "data.table")
-  expect_named(simTest$yieldTablesId, c("pixelId", "gcid"), ignore.order = TRUE)
-  expect_setequal(simTest$yieldTablesId$pixelId, yieldTablesId$pixelId)
+  expect_named(simTest$yieldTablesId, c("pixelIndex", "gcid"), ignore.order = TRUE)
+  expect_setequal(simTest$yieldTablesId$pixelIndex, yieldTablesId$pixelIndex)
   expect_equal(length(unique(simTest$yieldTablesId$gcid)), length(unique(yieldTablesId$gcid)))
   expect_setequal(simTest$yieldTablesId$gcid, simTest$yieldTablesCumulative$gcid)
 
@@ -90,19 +90,19 @@ test_that("module runs with small example", {
   # check aboveGroundBiomass
   expect_is(simTest$aboveGroundBiomass, "data.table")
   expect_named(simTest$aboveGroundBiomass,
-               c("pixelId", "speciesCode", "age", "merch", "foliage", "other"),
+               c("pixelIndex", "speciesCode", "age", "merch", "foliage", "other"),
                ignore.order = TRUE)
   
   # check aboveGroundIncrements
   expect_is(simTest$aboveGroundIncrements, "data.table")
   expect_named(
     simTest$aboveGroundIncrements, 
-    c("pixelId", "speciesCode", "age", "merchInc", "foliageInc", "otherInc"),
+    c("pixelIndex", "speciesCode", "age", "merchInc", "foliageInc", "otherInc"),
     ignore.order = TRUE
   )
   expect_equal(sum(simTest$aboveGroundIncrements$merchInc), 0 ) # there is not growth/mortality in the test
 
-  #check summaryAGB
+  # check summaryAGB
   expect_is(simTest$summaryAGB, "data.table")
   expect_named(
     simTest$summaryAGB, 
@@ -110,5 +110,14 @@ test_that("module runs with small example", {
     ignore.order = TRUE
   )
   expect_contains(simTest$summaryAGB$year, c(2011:2016))
+  
+  # check disturbanceEvents
+  expect_is(simTest$disturbanceEvents, "data.table")
+  expect_named(
+    simTest$disturbanceEvents, 
+    c("pixelIndex", "year", "eventID"),
+    ignore.order = TRUE
+  )
+  expect_equal(nrow(simTest$disturbanceEvents), 0)
   
 })


### PR DESCRIPTION
These changes should bring us closer to the data needed to run CBM!

I changed the format of the module outputs. Here is the summary.

**Object needed for CBM**
1. `cohortDT`: Includes the cohort-level information and will be updated every year. It has the columns `cohortID`, `pixelIndex`, `age`, `gcids`. The `cohortID` is the unique identifier for cohort _i_ (species x age) in pixel _j_.
2. `growth_increments`: Gives us the increments in each pool for each `gcids` x `age`. Gets updated each year. Columns are `gcids`,`age`, `merch_inc`, `foliage_inc`, `other_inc`. At time 0, there is also an additional column called `yieldTableIndex` which I kept simply to facilitate plotting. There are a single *yield table* per pixel (but several pixels with the same yield table), which contain a *growth curve (gcids)* for each species.
3. `gcMeta`: Growth curve-level information. This will be updated each year. It gives us the `species_id` (canfi code), `speciesCode` (LandR species code), and `sw_hw` (coded as either "sw" or "hw") associated with each `gcids`.
4. `standDT`: pixel-level information. Contains `pixelIndex` and `spatial_unit_id`. Does not change every year.

The objects are sligthly different at time 0 (for the spinup) than at time t (for the annual event): 

- During the spinup: Many cohorts will have the same `gcids`. For example, the growth curve of white spruce produced in `LandR` will be the same wherever it grows with the same group of species and within the same `LandR` ecoregion. The `growth_increments` are actual growth curves, close to what `CBM` actually uses to simulate growth.
- During the annual event: We do not use *growth curve* since LandR gives us directly the growth increment. Each cohort will have a different `gcids`. Actually, `cohortID` should be == to `gcids`. This means that `cohortDT`, `growth_increments`, and `gcMeta` all have the same number of rows (one per `cohortID`). In theory, if we cbind cohortDT, growth_increments, gcMeta, we would get the cohort information and their increments for each pool for each `pixelIndex`.

**Other objects**
5. `aboveGroundBiomass`: the above ground biomass in each pool x cohort x pixel. Gets updated each timestep. The columns are `pixelIndex`, `speciesCode`, `age`, `merch`, `foliage`, `other`
6. `summaryAGB`: Keep track of the biomass for each species at each timestep across the landscape. Columns are `year`, `speciesCode`, `merch`, `foliage`, `other`.
7. `yieldTablesCumulative`: Returns the yield tables divided by pools. Columns are `yieldTableIndex`, `speciesCode`, `age`, `merch`, `foliage`, `other`.
8. `yieldTablesId`: Spatially reference the yield tables. There are a single *yield table* per pixel, which contain a *growth curve; gcids* for each species. Columns are `pixelIndex`, `yieldTableIndex`.
9. `disturbanceEvents`: This is work in progress, but this would allow to transfer the disturbances simulated in `LandR` (e.g., fire in `scfm`, pests, harvest) to `CBM`. It has the columns `pixelIndex`, `year`, `eventID`. I plan to add a parameter to have the option to either 1) only use the disturbances produces by other modules, 2) only use the disturbances by a predetermine layer (as in CBM), or 3) both: add disturbances produces by other modules to disturbances predetermined.

I've managed to run the module on its own :
https://github.com/DominiqueCaron/LandRCBM/blob/main/global_split3poolsDefault.R 
and with LandR: 
https://github.com/DominiqueCaron/LandRCBM/blob/main/global_LandRtoSplit3pools.R

**Next steps**
1. Tests: The unit tests needs a significant update and new tests need to be added.
2. Cleaning and documentation: The module metadata and .Rmd needs to be updated and more detailed. Already, this text will serve as a good basis. I also need to do some cleanup of the code and probably add comments.
3. Optimization: I noticed that in a couple places there are operations that seems to be repeated. This should be relatively quick and small changes.
4. By the time I am done with 1-3, I think that the changes in `CBM_core` spinup events will be, or close to be, implemented. After that, I think that we should be ready to try to see if we are able to run the spinup!

