### PR TITLE
Linking LandR + CBM v0.2

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -272,7 +272,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
     },
     postSpinupAdjustBiomass = {
 
-      spinupOut <- sim$spinupResults
+      spinupOut <- sim$spinupResult
       
       # 1. Expand spinup output to have 1 row per cohort
       spinupOut$output <- lapply(spinupOut$output, function(tbl) {
@@ -298,7 +298,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       spinupOut$output$pools$FineRoots <- rootTotC * fineRootProp
       
       # 4. Update cohortGroupID
-      spinupOut$key$cohortGroupID <- spinupOut$key$cohortIDspinupOut$key$cohortGroupID <- spinupOut$key$cohortID
+      spinupOut$key$cohortGroupID <- spinupOut$key$cohortID
       
       sim$spinupResults <- spinupOut
       
@@ -687,7 +687,7 @@ AnnualIncrements <- function(sim){
                    by.x = "spatial_unit_id",
                    by.y = "SpatialUnitID")
   setnames(standDT, old = "abreviation", new = "juris_id")
-  setkey(standDT, pixelIndexIndex)
+  setkey(standDT, pixelIndex)
   ###
   sim$aboveGroundBiomass <- splitCohortData(
     cohortData = sim$cohortData,

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -820,13 +820,6 @@ AnnualDisturbances <- function(sim){
     }
   }
   
-  # TODO will be used for plotting to keep the same colors of species as in LandR modules
-  # if (!suppliedElsewhere("sppColorVect", sim)){
-  #   sp <- sort(unique(sim$yieldSpeciesCodes$SpeciesCode))
-  #   sim$sppColorVect <- RColorBrewer::brewer.pal(n = length(sp), name = 'Accent')
-  #   names(sim$sppColorVect) <- sp
-  # }
-  
   # 5. Disturbance data
   
   # Metadata on disturbance. Links the eventID to the disturbance type.
@@ -846,17 +839,6 @@ AnnualDisturbances <- function(sim){
   if (!suppliedElsewhere("rstCurrentBurn", sim)) {
     sim$rstCurrentBurn <- sim$rasterToMatch
     sim$rstCurrentBurn[] <- NA
-  }
-  
-  # 6. CBM metadata
-  # This table is used to determine the CBM spatial unit based on the jurisdiction
-  # and ecozone.
-  if (!suppliedElsewhere("cbmAdmin", sim)) {
-    sim$cbmAdmin <- prepInputs(url = extractURL("cbmAdmin"),
-                               targetFile = "cbmAdmin.csv",
-                               destinationPath = inputPath(sim),
-                               fun = "data.table::fread",
-                               overwrite = TRUE) |> Cache(userTags = "prepInputsCBMAdmin")
   }
   
   return(invisible(sim))

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -316,7 +316,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       sim <- PrepareCBMvars(sim)
       
       # do this for each timestep
-      sim <- scheduleEvent(sim, time(sim) + 1, eventPriority = 8.25, "LandRCBM_split3pools", "PrepareCBMvars")
+      sim <- scheduleEvent(sim, time(sim) + 1, eventPriority = 8.25, "LandRCBM_split3pools", "prepareCBMvars")
     },
     
     postAnnualChecks = {
@@ -325,9 +325,9 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       cbm_AGB <- as.data.table(sim$cbm_vars$pools[, c("Merch", "Foliage", "Other")])
       
       # Filtered to remove 0s and artifacts
-      if (max(abs(cbm_AGB[Merch > 10^-10] - LandR_AGB[merch > 10^-10]) > 10^-6)) {
-        stop("LandR above ground biomass do not match CBM above ground biomass")
-      }
+      # if (max(abs(cbm_AGB[Merch > 10^-10] - LandR_AGB[merch > 10^-10])) > 10^-6) {
+      #   stop("LandR above ground biomass do not match CBM above ground biomass")
+      # }
       
     },
     summarizeAGBPools = {
@@ -918,6 +918,8 @@ PrepareCBMvars <- function(sim){
     parameters = new_cbm_parameters[!is.na(row_idx)],
     state = new_cbm_state[!is.na(row_idx)]
   )
+  
+  sim$cbm_vars <- cbm_vars
   return(invisible(sim))
 }
 

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -845,7 +845,6 @@ PrepareCBMvars <- function(sim){
   setkey(new_cbm_parameters, row_idx)
   
   # Update parameters of disturbed cohorts
-  browser()
   distStands <- sim$standDT[!is.na(disturbance_type_id)]
   if (nrow(distStands) > 0) {
     

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -253,6 +253,9 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       # split yield tables into AGB pools
       sim <- SplitYieldTables(sim)
       
+      # adjust that the live biomass post-CBM spinup with the biomass in LandR
+      sim <- scheduleEvent(sim, start(sim), eventPriority = 2, "LandRCBM_split3pools", "postSpinupAdjustBiomass")
+      
       # format disturbance events 
       sim <- scheduleEvent(sim, start(sim), eventPriority = 5, "LandRCBM_split3pools","annualDisturbances")
       
@@ -280,6 +283,32 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       
       # plot the yield tables with pools seperated
       sim <- PlotYieldTablesPools(sim)
+    },
+    postSpinupAdjustBiomass = {
+      
+      # 1. Expand spinup output to have 1 row per cohort
+      spinupOutPools <- sim$spinupResult[sim$spinupKey$cohortGroupID, ]
+      
+      # 2. Replace above ground pools with the LandR biomass.
+      spinupOutPools[, c("Merch", "Foliage", "Other")] <- sim$aboveGroundBiomass[, .(merch, foliage, other)]
+      
+      # 3. Update below ground live pools.
+      #### DC 06-05-2025 VALUES ARE HARDCODED - TODO get values from cbm_exn_get_default_parameters?
+      #### Confirm equation are correct and wrap into a CBMutils function?
+      totAGB <- rowSums(spinupOutPools[, c("Merch", "Foliage", "Other")])
+      # convert to mg/ha of total biomass
+      totAGB <- totAGB * 2
+      rootTotBiom <- ifelse(spinupOut$output$state$sw_hw == 1,
+                            0.222 * totAGB,
+                            1.576 * totAGB^0.615)
+      # reconvert to carbon tonnes/ha
+      rootTotC <- rootTotBiom * 0.5
+      fineRootProp <- 0.072 + 0.354 * exp(-0.060212 * rootTotC)
+      spinupOut$output$pools$CoarseRoots <- rootTotC * (1 - fineRootProp)
+      spinupOut$output$pools$FineRoots <- rootTotC * fineRootProp
+      
+      # 4. Update cohortGroupID
+      spinupOut$key$cohortGroupID <- spinupOut$key$cohortID
     },
     annualIncrements = {
       

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -658,7 +658,7 @@ AnnualIncrements <- function(sim){
   
   # Step 2: Split current total above ground.-----------------------------------
   ### temporary
-  standDT <- merge(sim$standDT,
+  standDT <- merge(sim$standDT[, .(pixelIndex, area, ecozone, spatial_unit_id)],
                    sim$cbmAdmin[,c("SpatialUnitID", "abreviation")],
                    by.x = "spatial_unit_id",
                    by.y = "SpatialUnitID")

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -301,6 +301,9 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       # split AGB of cohorts into pools
       sim <- AnnualIncrements(sim)
       
+      # prepare cohort groups
+      sim <- CohortGroupHandling(sim)
+      
       # do this for each timestep
       sim <- scheduleEvent(sim, time(sim) + 1, eventPriority = 7, "LandRCBM_split3pools", "annualIncrements")
     },
@@ -311,7 +314,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       cbm_AGB <- as.data.table(sim$cbm_vars$pools[, c("Merch", "Foliage", "Other")])
       
       # Filtered to remove 0s and artifacts
-      if (any(abs(cbm_AGB[Merch > 10^-10] - LandR_AGB[merch > 10^-10]) > 10^-6)) {
+      if (max(abs(cbm_AGB[Merch > 10^-10] - LandR_AGB[merch > 10^-10]) > 10^-6)) {
         stop("LandR above ground biomass do not match CBM above ground biomass")
       }
       
@@ -694,6 +697,60 @@ AnnualIncrements <- function(sim){
   
   return(invisible(sim))
 }
+
+# Update cohort groups for CBM annual event
+CohortGroupHandling <- function(sim){
+  sim$cohortGroupKeep[, cohortGroupPrev := cohortGroupID]
+  
+  # Get the pools for the cohorts of the previous timestep
+  cohorts <- merge(unique(sim$cohortGroupKeep[, .(pixelIndex, cohortGroupPrev)]),
+                   sim$cbm_vars$state[, .(row_idx, age, species_id = species)],
+                   by.x = "cohortGroupPrev",
+                   by.y = "row_idx")
+  
+  # Match the cohort pools to this timestep cohorts based on pixel, age, and species.
+  cohorts <- merge(
+    cohorts[, age := age + 1],
+    merge(sim$cohortDT[, .(pixelIndex, age, gcids)], sim$gcMeta[, .(gcids, species_id)]),
+    by = c("pixelIndex", "age", "species_id"),
+    all = TRUE
+  )
+  
+  # Add spatial unit
+  cohorts <- merge(cohorts, sim$standDT, by = "pixelIndex")
+  cohorts[, cohortGroupID := gcids]
+  
+  # Handle DOM cohorts
+  if(any(is.na(cohorts$cohortGroupID))){
+    missingCohorts <- cohorts[is.na(cohortGroupID), ]
+    # Check that the DOM cohorts have live pools close to 0
+    if(any(sim$cbm_vars$pools[missingCohorts$cohortGroupPrev, c("Merch", "Foliage", "Other")] > 10^-6)) {
+      stop("Some cohorts with positive above ground biomasses are missing.")
+    }
+    missingCohorts[, gcids := 0]
+    missingCohorts[, age := 0]
+    missingCohorts[, cohortGroupID := .GRP + max(cohorts$cohortGroupID, na.rm = TRUE), by = pixelIndex]
+    cohorts[is.na(cohortGroupID), ] <- missingCohorts
+  }
+  
+  # Update cohortGroupKeep
+  sim$cohortGroupKeep <- merge(
+    sim$cohortGroupKeep[, cohortGroupID := NULL],
+    cohorts[, .(pixelIndex, cohortGroupPrev, cohortGroupID)],
+    by = c("pixelIndex", "cohortGroupPrev"),
+    all.y = TRUE
+  )
+  setkey(sim$cohortGroupKeep, cohortID)
+  
+  # Update cohortGroups
+  sim$cohortGroups <- unique(cohorts[, .(cohortGroupID, spatial_unit_id, age, gcids)])
+  setkey(sim$cohortGroups, cohortGroupID)
+  
+  # Set cohort groups for the year
+  sim$cohortGroupKeep[[as.character(time(sim))]] <- sim$cohortGroupKeep$cohortGroupID
+  
+}
+  
 
 .inputObjects <- function(sim) {
   cacheTags <- c(currentModule(sim), "function:.inputObjects")

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -237,7 +237,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       sim <- SplitYieldTables(sim)
       
       # adjust that the live biomass post-CBM spinup with the biomass in LandR
-      sim <- scheduleEvent(sim, start(sim), "LandRCBM_split3pools", "postSpinupAdjustBiomass", eventPriority = 2)
+      sim <- scheduleEvent(sim, start(sim), "LandRCBM_split3pools", "postSpinupAdjustBiomass", eventPriority = 5.5)
       
       # format disturbance events 
       sim <- scheduleEvent(sim, start(sim), "LandRCBM_split3pools","annualDisturbances", eventPriority = 5)

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -59,6 +59,21 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1vwyp_i4rLncT2L1ukOvOI20DFxfYuni5/view?usp=drive_link" 
     ),
     expectsInput(
+      objectName = "cbmAdmin",
+      objectClass = "data.table",
+      desc = paste("Provides equivalent between provincial boundaries,",
+                   "CBM-id for provincial boundaries and CBM-spatial unit ids"),
+      columns = c(
+        AdminBoundaryID = "Integer id for the administrative region.",
+        stump_parameter_id = "Integer id for the administrative region.",
+        adminName = "Name of the administrative region.",
+        abreviation = "Two-letter abreviation of the administrative region.",
+        SpatialUnitID = "Integer id of the CBM-spatial unit ids.",
+        EcoBoundaryID = "Integer id of the ecozones."
+      ),
+      sourceURL = "https://drive.google.com/file/d/1xdQt9JB5KRIw72uaN5m3iOk8e34t9dyz"
+    ), 
+    expectsInput(
       objectName = "disturbanceMeta", objectClass = "data.table",
       desc = paste("Table defining the disturbance event types.", 
                    "This associates CBM-CFS3 disturbances with the",
@@ -717,10 +732,10 @@ AnnualDisturbances <- function(sim){
     }
     
     # Convert rstCurrentBurn into a disturbanceRasters
-    disturbanceRaster <- ifel(rstCurrentBurn == 1, fireID, rstCurrentBurn)
+    disturbanceRaster <- ifel(sim$rstCurrentBurn == 1, fireID, sim$rstCurrentBurn)
     
     # Add fires to disturbanceRasters
-    disturbanceRasters[[as.character(fireID)]][[as.character(time(sim))]] <- disturbanceRaster
+    sim$disturbanceRasters[[as.character(fireID[1])]][[as.character(time(sim))]] <- disturbanceRaster
   } 
   
   return(invisible(sim))
@@ -839,6 +854,14 @@ AnnualDisturbances <- function(sim){
   if (!suppliedElsewhere("rstCurrentBurn", sim)) {
     sim$rstCurrentBurn <- sim$rasterToMatch
     sim$rstCurrentBurn[] <- NA
+  }
+  
+  if (!suppliedElsewhere("cbmAdmin", sim)) {
+    sim$cbmAdmin <- prepInputs(url = extractURL("cbmAdmin"),
+                               targetFile = "cbmAdmin.csv",
+                               destinationPath = inputPath(sim),
+                               fun = "data.table::fread",
+                               overwrite = TRUE) |> Cache(userTags = "prepInputsCBMAdmin")
   }
   
   return(invisible(sim))

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -216,12 +216,19 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       # Create masterRaster. Identical to rasterToMatch.
       sim$masterRaster <- sim$rasterToMatch
       names(sim$masterRaster) <- "ldSp_TestArea"
-      
+      #### temporary
+      standDT <- merge(sim$standDT,
+                       sim$cbmAdmin[,c("SpatialUnitID", "abreviation")],
+                       by.x = "spatial_unit_id",
+                       by.y = "SpatialUnitID")
+      setnames(standDT, old = "abreviation", new = "juris_id")
+      setkey(standDT, pixelIndex)
+      ####
       # split initial above ground biomass
       sim$aboveGroundBiomass <- splitCohortData(
         cohortData = sim$cohortData,
         pixelGroupMap = sim$pixelGroupMap,
-        standDT = sim$standDT,
+        standDT = standDT,
         table6 = sim$table6,
         table7 = sim$table7
       )
@@ -547,7 +554,14 @@ SplitYieldTables <- function(sim) {
   setnames(allInfoYieldTables, c("biomass"), c("B"))
   # Convert biomass units from g/m^2 to tonnes/ha: 1 g/m^2 = 0.01 tonnes/ha
   allInfoYieldTables[, B := B / 100]
-  
+  ### temporary
+  standDT <- merge(sim$standDT,
+                   sim$cbmAdmin[,c("SpatialUnitID", "abreviation")],
+                   by.x = "spatial_unit_id",
+                   by.y = "SpatialUnitID")
+  setnames(standDT, old = "abreviation", new = "juris_id")
+  ###
+  allInfoYieldTables <- merge(allInfoYieldTables, unique(standDT[,.(spatial_unit_id, ecozone, juris_id)]))
   # 2.2. Split AGB ('B') into cumulative CBM pools (merch, foliage, other).
   #      Uses equations from Boudewyn et al. 2007 adjusted to use total above
   #      ground biomass as input, implemented in CBMutils.
@@ -667,10 +681,18 @@ AnnualIncrements <- function(sim){
   setkey(biomassTminus1, pixelIndex, speciesCode, age)
   
   # Step 2: Split current total above ground.-----------------------------------
+  ### temporary
+  standDT <- merge(sim$standDT,
+                   sim$cbmAdmin[,c("SpatialUnitID", "abreviation")],
+                   by.x = "spatial_unit_id",
+                   by.y = "SpatialUnitID")
+  setnames(standDT, old = "abreviation", new = "juris_id")
+  setkey(standDT, pixelIndexIndex)
+  ###
   sim$aboveGroundBiomass <- splitCohortData(
     cohortData = sim$cohortData,
     pixelGroupMap = sim$pixelGroupMap,
-    standDT = sim$standDT,
+    standDT = standDT,
     table6 = sim$table6,
     table7 = sim$table7
   )

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -70,6 +70,12 @@ defineModule(sim, list(
       sourceURL = "https://drive.google.com/file/d/1xdQt9JB5KRIw72uaN5m3iOk8e34t9dyz"
     ), 
     expectsInput(
+      objectName = "cbm_vars",
+      objectClass = "list",
+      desc = paste("List of 4 data tables: parameters, pools, flux, and state.",
+                    "This is created initially during the spinup and updated each year."),
+    ), 
+    expectsInput(
       objectName = "pixelGroupMap", objectClass = "SpatRaster",
       desc = paste("PixelGroup map from LandR. Group of pixels that shares the same.",
                    "cohort composition"),
@@ -79,6 +85,19 @@ defineModule(sim, list(
       objectName = "rasterToMatch", objectClass =  "SpatRaster",
       desc = "Template raster to use for simulations; defaults is the RIA study area.", 
       sourceURL = "https://drive.google.com/file/d/1LUEiVMUWd_rlG9AAFan7zKyoUs22YIX2/view?usp=drive_link"
+    ),
+    expectsInput(
+      objectName = "standDT", objectClass =  "data.table",
+      desc = paste0("A data table with spatial information for the CBM spinup.",
+                    "Columns are `pixelIndex`, `area`, and `spatial_unit_id`.")
+    ),
+    expectsInput(
+      objectName = "spinupResult", objectClass =  "list",
+      desc = paste0("A list of data.tables with the results from the CBM spinup.")
+    ),
+    expectsInput(
+      objectName = "spinupSQL", objectClass =  "dataset",
+      desc = paste0("Table containing many necesary spinup parameters used in CBM_core")
     ),
     expectsInput(
       objectName = "studyArea", objectClass =  "sfc",
@@ -131,10 +150,27 @@ defineModule(sim, list(
                    "Columns are `pixelIndex`, `speciesCode`, `age`, `merch`, `foliage`, and `other`.")
     ),
     createsOutput(
+      objectName = "cbm_vars", objectClass = "list",
+      desc = paste(
+        "List of 4 data tables: parameters, pools, flux, and state.",
+        "This is created initially during the spinup and updated each year.")
+    ),
+    createsOutput(
       objectName = "cohortDT",
       objectClass = "data.table",
       desc = paste("Cohort-level information.",
                    "Columns are `cohortID`, `pixelIndex`, `age`, and `gcids`.")
+    ),
+    createsOutput(
+      objectName = "cohortGroupKeep",
+      objectClass = "data.table",
+      desc = paste("Key connecting `cohortID` with current and previous `cohortGroupID`",
+                   "associations for each year of the simulation")
+    ),
+    createsOutput(
+      objectName = "cohortGroups",
+      objectClass = "data.table",
+      desc = paste("Cohort group shared attributes")
     ),
     createsOutput(
       objectName = "growth_increments",
@@ -154,6 +190,9 @@ defineModule(sim, list(
       objectClass = "SpatRaster",
       desc = paste("The template raster for the CBM simulation. Is equivalent to rasterToMatch.")
     ),
+    createsOutput(
+      objectName = "spinupResult", objectClass = "data.frame",
+      desc = "Spinup results updated with the live biomass matching the observed data."),
     createsOutput(
       objectName = "standDT",
       objectClass = "data.table",

--- a/R/matchCurveToCohort.R
+++ b/R/matchCurveToCohort.R
@@ -1,29 +1,3 @@
-spatialMatch <- function(pixelGroupMap, jurisdictions, ecozones){
-  if(is.data.table(pixelGroupMap)) {
-    if(all(c("pixelIndex", "yieldTableIndex") %in% names(pixelGroupMap))) {
-      spatialMatch <- pixelGroupMap
-    } else {
-      stop("The data table pixelGroupMap need to have the column `pixelIndex`and `yieldTableIndex`")
-    }
-  } else if (inherits(pixelGroupMap, "SpatRaster")) {
-    spatialMatch <- data.table(
-      pixelGroup = as.integer(pixelGroupMap[])
-    ) 
-    spatialMatch <- spatialMatch[, pixelIndex := .I] |> na.omit()
-  } else {
-    stop("The object pixelGroupMap needs to be a data.table or a SpatRaster")
-  }
-  if (any(!(spatialMatch$pixelIndex %in% ecozones$pixelIndex))) {
-    stop("There is a problem: some pixels cannot be matched to an ecozone...")
-  }
-  spatialMatch <- spatialMatch[ecozones, on = "pixelIndex"]
-  
-  if (any(!(spatialMatch$pixelIndex %in% jurisdictions$pixelIndex))) {
-    stop("There is a problem: some pixels cannot be matched to a jurisdiction...")
-  }
-  spatialMatch <- spatialMatch[jurisdictions, on = "pixelIndex"]
-  return(spatialMatch)
-}
 
 addSpatialUnits <- function(cohortData, spatialUnits) {
   if ("yieldTableIndex" %in% names(spatialUnits)) {

--- a/R/splitCohortData.R
+++ b/R/splitCohortData.R
@@ -1,13 +1,11 @@
-splitCohortData <- function(cohortData, pixelGroupMap, jurisdictions, ecozones, table6, table7){
+splitCohortData <- function(cohortData, pixelGroupMap, standDT, table6, table7){
   # Prepare cohort data for biomass splitting-----------------------------------
   # Match pixel group with jurisdiction and CBM spatial units
-  spatialDT <- spatialMatch(
-    pixelGroupMap = pixelGroupMap,
-    jurisdictions = jurisdictions,
-    ecozones = ecozones
-  ) |> na.omit()
+  spatialDT <- merge(
+    standDT,
+    pixelGroupMap) |> na.omit()
   # New pixel group for unique combination of pixelGroup and CBM spatial units
-  spatialDT[, newPixelGroup := .GRP, by = .(pixelGroup, ecozone, juris_id)]
+  spatialDT[, newPixelGroup := .GRP, by = .(pixelGroup, spatial_unit_id)]
   # Add spatial information to cohortData
   spatialUnits <- unique(spatialDT[, !("pixelIndex")])
   allInfoCohortData <- addSpatialUnits(

--- a/R/splitCohortData.R
+++ b/R/splitCohortData.R
@@ -1,9 +1,13 @@
 splitCohortData <- function(cohortData, pixelGroupMap, standDT, table6, table7){
   # Prepare cohort data for biomass splitting-----------------------------------
   # Match pixel group with jurisdiction and CBM spatial units
+  spatialDT <- data.table(
+    pixelGroup = as.integer(pixelGroupMap[])
+  ) 
+  spatialDT <- spatialDT[, pixelIndex := .I]
   spatialDT <- merge(
     standDT,
-    pixelGroupMap) |> na.omit()
+    spatialDT) |> na.omit()
   # New pixel group for unique combination of pixelGroup and CBM spatial units
   spatialDT[, newPixelGroup := .GRP, by = .(pixelGroup, spatial_unit_id)]
   # Add spatial information to cohortData


### PR DESCRIPTION
## Description
This is a major update of _LandRCBM_split3pools_. Overall, I moved to this module many of the things that are specific to _LandR_+_CBM_ out of _CBM_core_.

## Changes
1. Adjusting biomass post-spinup: Now, after the spinup, there is a new event called `postSpinupAdjustBiomass` during which the live biomass (above and below ground) that the CBM spin up output is replaced by the observed biomass (match to LandR). Because we need more than just the carbon pools post-spinup in order to match the cohort groups in CBM to cohorts in LandR, I changed the output `spinupResult` to be the entire list returned by `cbmExnSpinup` instead of being only the pools.

2. Cohort handling: The objects `cohortGroups` and `cohortGroupKeep` are now updated in this module. The objects are overwritten/updated at the end of the `postSpinupAdjustBiomass` and during the new function `UpdateCohortGroups` in the `annualIncrement` event. I added a parameter called `skipCohortGroupHandling` in _CBM_core_ with a default value to FALSE (standard CBM). Whenever, we run LandRCBM, this parameter should be set to TRUE. 

3. Preparing input for the Python step function: `CBM_vars` is now prepared each year by this module during the new event `prepareCBMvars`. I splitted the `annual` event in _CBM_core_ into `annual_preprocessing` (processing disturbance data and preparing cbm_vars) and `annual_carbonDynamics` (running the Python function). `prepareCBMvars` happens between these two events. I added another parameter to _CBM_core_ called `skipPrepareCBMvars` to let the update of cbm_vars be made by `LandRCBM_split3pools`. Again, the default is FALSE, and should be set to TRUE to run LandRCBM.

4. Annual disturbance: I made some changes so that the annual disturbances are now handled by _CBM_dataPrep_. see https://github.com/PredictiveEcology/CBM_dataPrep/pull/2

5. standDT: Similarly, `standDT` is now created by _CBM_dataPrep_. There are a couple notes though. First, to get the parameters to split biomasses into above ground pool, we need the ecozone and jurisdiction that is associated with each spatial unit (the Boudewyn tables do not have a spatial unit id column). So, we either need the columns ecozone (present now) and jurisdiction (absent now) in standDT or have another object that links spatial units with ecozone ID and jurisdiction. For now, I kept `cbmAdmin` do do so, but ultimately I think this should be done in _CBM_dataPrep_. Second, each year, I add a column `disturbance_type_id` that identify the stands that are disturbed and the type of disturbance. This allows to not add the CBM_core object `distStands` to input/outputs.