### PR TITLE
Implementing cohort groups

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -684,7 +684,9 @@ AnnualIncrements <- function(sim){
     other_inc   = other   - otherTminus1
   )]
   # Create gcids and cohortID (the same for annual increments).
-  incrementsDT[, c("gcids", "cohortID") := .(.I, .I)]
+  groupCols <- c("speciesCode", "age", "merch_inc", "foliage_inc", "other_inc")
+  incrementsDT[, gcids := .GRP, by = groupCols]
+  incrementsDT[, cohortID := .I]
   # Add CBM species_id for gcMeta (is named newCode in incrementsDT)
   incrementsDT <- addSpeciesCode(incrementsDT, code = "CBM_speciesID")
   # Add forest type ("sw" or "hw") for gcMeta
@@ -692,7 +694,7 @@ AnnualIncrements <- function(sim){
   # Create data.table with cohort-level information
   sim$cohortDT <- incrementsDT[, .(cohortID, pixelIndex, age, gcids)]
   # Creta data.table with growth curve-level information
-  sim$gcMeta <- incrementsDT[, .(gcids, species_id = newCode, speciesCode, sw_hw)]
+  sim$gcMeta <- unique(incrementsDT[, .(gcids, species_id = newCode, speciesCode, sw_hw)])
   # Create final growth increment data.table
   sim$growth_increments <- incrementsDT[, .(gcids, age, merch_inc, foliage_inc, other_inc)]
   setkey(sim$growth_increments, gcids)
@@ -847,11 +849,11 @@ PrepareCBMvars <- function(sim){
     # Remove new cohorts
     distCohorts <- distCohorts[!is.na(cohortGroupPrev)]
     
-    new_cbm_parameters[distCohorts$cohortGroupID, "disturbance_type"] <- distCohorts$disturbance_type_id
+    new_cbm_parameters[unique(distCohorts$cohortGroupID), "disturbance_type"] <- distCohorts$disturbance_type_id
     # DC 29-04-2025: Not sure what should be the increments for disturbed cohorts.
-    new_cbm_parameters[distCohorts$cohortGroupID, merch_inc := 0L]
-    new_cbm_parameters[distCohorts$cohortGroupID, foliage_inc := 0L]
-    new_cbm_parameters[distCohorts$cohortGroupID, other_inc := 0L]
+    new_cbm_parameters[unique(distCohorts$cohortGroupID), merch_inc := 0L]
+    new_cbm_parameters[unique(distCohorts$cohortGroupID), foliage_inc := 0L]
+    new_cbm_parameters[unique(distCohorts$cohortGroupID), other_inc := 0L]
   }
   
   # 4. Prepare cbm state

--- a/tests/testthat/test-4-LandRCBM_split3pools.R
+++ b/tests/testthat/test-4-LandRCBM_split3pools.R
@@ -145,7 +145,6 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   simTest <- SpaDEStestMuffleOutput(
     SpaDES.core::spades(simTestInit)
   )
-  
   # Run tests
   expect_s4_class(simTest, "simList")
   
@@ -170,7 +169,6 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   # check cbm_vars
   expect_is(simTest$cbm_vars, "list")
   expect_named(simTest$cbm_vars, c("pools", "flux", "parameters", "state"))
-  expect_equal(nrow(simTest$cbm_vars$pools), nrow(simTest$aboveGroundBiomass))
   expect_equal(nrow(simTest$cbm_vars$pools), nrow(simTest$cohortGroups))
   expect_equal(simTest$cbm_vars$pools$Merch, simTest$aboveGroundBiomass$merch)
   expect_equal(simTest$cbm_vars$pools$Foliage, simTest$aboveGroundBiomass$foliage)


### PR DESCRIPTION
A first shot at grouping cohorts. Probably not perfect, but it seems to have decrease the time and RAM to run the test area (40 000 km2) for 30 years by ~25%, so not bad.

The tricky part is that cohort groups need to share both the same above ground increments (determined by LandR) and existing below ground (CBM_core). Adding to this, there are DOM cohorts that cannot be grouped more than at the pixel-level.

