### PR TITLE
Optimizing v2

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -274,7 +274,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       # 3. Update below ground live pools.
       rootsC <- CBMutils::calcRootC(spinupOut$output$pools, spinupOut$output$state$sw_hw)
       spinupOut$output$pools[, c("CoarseRoots", "FineRoots")] <- rootsC
-      
+
       # 4. Update cohortGroupID
       spinupOut <- updateSpinupCohortGroups(spinupOut)
       
@@ -708,18 +708,20 @@ UpdateCohortGroups <- function(sim){
   cohorts <- merge(unique(sim$cohortGroupKeep[, .(pixelIndex, cohortGroupPrev)]),
                    sim$cbm_vars$state[, .(row_idx, age, species_id = species)],
                    by.x = "cohortGroupPrev",
-                   by.y = "row_idx")
+                   by.y = "row_idx",
+                   sort = FALSE)
   
   # Match the cohort pools to this timestep cohorts based on pixel, age, and species.
   cohorts <- merge(
     cohorts[, age := age + 1],
     merge(sim$cohortDT[, .(pixelIndex, age, gcids)], sim$gcMeta[, .(gcids, species_id)]),
     by = c("pixelIndex", "age", "species_id"),
-    allow.cartesian = TRUE
+    allow.cartesian = TRUE,
+    sort = FALSE
   )
   
   # Add spatial unit
-  cohorts <- merge(cohorts, sim$standDT, by = "pixelIndex")
+  cohorts <- merge(cohorts, sim$standDT, by = "pixelIndex", sort = FALSE)
   # Cohort groups have the same increments and the same group in the previous timestep
   cohorts[, cohortGroupID := .GRP, by = c("cohortGroupPrev", "gcids")]
   
@@ -740,7 +742,8 @@ UpdateCohortGroups <- function(sim){
     sim$cohortGroupKeep[, cohortGroupID := NULL],
     cohorts[, .(pixelIndex, cohortGroupPrev, cohortGroupID)],
     by = c("pixelIndex", "cohortGroupPrev"),
-    all.y = TRUE
+    all.y = TRUE,
+    sort = FALSE
   )
   setkey(sim$cohortGroupKeep, cohortID)
   

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -704,7 +704,6 @@ AnnualIncrements <- function(sim){
 # Update cohort groups for CBM annual event
 UpdateCohortGroups <- function(sim){
   sim$cohortGroupKeep[, cohortGroupPrev := cohortGroupID]
-  
   # Get the pools for the cohorts of the previous timestep
   cohorts <- merge(unique(sim$cohortGroupKeep[, .(pixelIndex, cohortGroupPrev)]),
                    sim$cbm_vars$state[, .(row_idx, age, species_id = species)],
@@ -721,7 +720,8 @@ UpdateCohortGroups <- function(sim){
   
   # Add spatial unit
   cohorts <- merge(cohorts, sim$standDT, by = "pixelIndex")
-  cohorts[, cohortGroupID := .GRP, by = c("gcids", "row_idx")]
+  # Cohort groups have the same increments and the same group in the previous timestep
+  cohorts[, cohortGroupID := .GRP, by = c("cohortGroupPrev", "gcids")]
   
   # Handle DOM cohorts
   if(any(is.na(cohorts$gcids))){

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -721,22 +721,18 @@ UpdateCohortGroups <- function(sim){
   
   # Add spatial unit
   cohorts <- merge(cohorts, sim$standDT, by = "pixelIndex")
-  cohorts <- merge(cohorts, sim$cbm_vars$pools, by.x = "cohortGroupPrev", by.y = "row_idx")
-  ### SPEED UP: LESS COLUMN IS FASTER FOR .GRP: COULD BE THE COHORT GROUP OF PREV + GCIDS
-  cohortGroupsIdentifiers <- c("gcids", setdiff(colnames(sim$cbm_vars$pools), "row_idx"))
-  cohorts[, cohortGroupID := .GRP, by = cohortGroupsIdentifiers]
+  cohorts[, cohortGroupID := .GRP, by = c("gcids", "row_idx")]
   
   # Handle DOM cohorts
-  if(any(is.na(cohorts$cohortGroupID))){
-    missingCohorts <- cohorts[is.na(cohortGroupID), ]
+  if(any(is.na(cohorts$gcids))){
+    missingCohorts <- cohorts[is.na(gcids), ]
     # Check that the DOM cohorts have live pools close to 0
     if(any(sim$cbm_vars$pools[missingCohorts$cohortGroupPrev, c("Merch", "Foliage", "Other")] > 10^-6)) {
       stop("Some cohorts with positive above ground biomasses are missing.")
     }
     missingCohorts[, gcids := 0]
     missingCohorts[, age := 0]
-    missingCohorts[, cohortGroupID := .GRP + max(cohorts$cohortGroupID, na.rm = TRUE), by = pixelIndex]
-    cohorts[is.na(cohortGroupID), ] <- missingCohorts
+    cohorts[is.na(gcids), ] <- missingCohorts
   }
   
   # Update cohortGroupKeep

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -262,7 +262,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
     },
     postSpinupAdjustBiomass = {
       spinupOut <- sim$spinupResult
-      
+
       # 1. Expand spinup output to have 1 row per cohort
       spinupOut$output <- lapply(spinupOut$output, function(tbl) {
         tbl <- tbl[spinupOut$key$cohortGroupID, ]
@@ -276,7 +276,7 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       spinupOut$output$pools[, c("CoarseRoots", "FineRoots")] <- rootsC
       
       # 4. Update cohortGroupID
-      spinupOut$key$cohortGroupID <- spinupOut$key$cohortID
+      spinupOut <- updateSpinupCohortGroups(spinupOut)
       
       sim$spinupResult <- spinupOut
       
@@ -722,6 +722,7 @@ UpdateCohortGroups <- function(sim){
   # Add spatial unit
   cohorts <- merge(cohorts, sim$standDT, by = "pixelIndex")
   cohorts <- merge(cohorts, sim$cbm_vars$pools, by.x = "cohortGroupPrev", by.y = "row_idx")
+  ### SPEED UP: LESS COLUMN IS FASTER FOR .GRP: COULD BE THE COHORT GROUP OF PREV + GCIDS
   cohortGroupsIdentifiers <- c("gcids", setdiff(colnames(sim$cbm_vars$pools), "row_idx"))
   cohorts[, cohortGroupID := .GRP, by = cohortGroupsIdentifiers]
   

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -261,7 +261,6 @@ doEvent.LandRCBM_split3pools = function(sim, eventTime, eventType) {
       sim <- PlotYieldTablesPools(sim)
     },
     postSpinupAdjustBiomass = {
-
       spinupOut <- sim$spinupResult
       
       # 1. Expand spinup output to have 1 row per cohort

--- a/R/updateSpinupCohortGroups.R
+++ b/R/updateSpinupCohortGroups.R
@@ -13,12 +13,13 @@ updateSpinupCohortGroups <- function(spinupOut){
   
   # Step 3: Update the cohortGroupID in the key table
   spinupOut$key$cohortGroupID <- combinedOutputs$cohortGroupID
-  
+
   # Step 4: Update spinup outputs
   spinupOut$output <- lapply(spinupOutputs, function(tbl){
     tbl$row_idx <- combinedOutputs$cohortGroupID
     tbl <- unique(tbl)
     tbl$row_idx <- NULL
+    tbl
   })
   
   return(spinupOut)

--- a/R/updateSpinupCohortGroups.R
+++ b/R/updateSpinupCohortGroups.R
@@ -1,0 +1,25 @@
+updateSpinupCohortGroups <- function(spinupOut){
+  spinupOutputs <- spinupOut$output
+  
+  # Step 1: Combine pools and state columns into a single data.table
+  # Round pools to mg/g
+  combinedOutputs <- cbind(
+    round(spinupOutputs$pools, 9),
+    spinupOutputs$state[, c("spatial_unit_id", "age", "species")]
+  ) |> as.data.table()
+  
+  # Step 2: Create a unique cohort group ID for identical rows
+  combinedOutputs[, cohortGroupID := .GRP, by = names(combinedOutputs)]
+  
+  # Step 3: Update the cohortGroupID in the key table
+  spinupOut$key$cohortGroupID <- combinedOutputs$cohortGroupID
+  
+  # Step 4: Update spinup outputs
+  spinupOut$output <- lapply(spinupOutputs, function(tbl){
+    tbl$row_idx <- combinedOutputs$cohortGroupID
+    tbl <- unique(tbl)
+    tbl$row_idx <- NULL
+  })
+  
+  return(spinupOut)
+}

--- a/R/updateSpinupCohortGroups.R
+++ b/R/updateSpinupCohortGroups.R
@@ -1,10 +1,9 @@
 updateSpinupCohortGroups <- function(spinupOut){
   spinupOutputs <- spinupOut$output
-  
   # Step 1: Combine pools and state columns into a single data.table
   # Round pools to mg/g
   combinedOutputs <- cbind(
-    round(spinupOutputs$pools, 9),
+    spinupOutputs$pools,
     spinupOutputs$state[, c("spatial_unit_id", "age", "species")]
   ) |> as.data.table()
   
@@ -13,7 +12,7 @@ updateSpinupCohortGroups <- function(spinupOut){
   
   # Step 3: Update the cohortGroupID in the key table
   spinupOut$key$cohortGroupID <- combinedOutputs$cohortGroupID
-
+  
   # Step 4: Update spinup outputs
   spinupOut$output <- lapply(spinupOutputs, function(tbl){
     tbl$row_idx <- combinedOutputs$cohortGroupID

--- a/R/updateSpinupCohortGroups.R
+++ b/R/updateSpinupCohortGroups.R
@@ -15,10 +15,11 @@ updateSpinupCohortGroups <- function(spinupOut){
   
   # Step 4: Update spinup outputs
   spinupOut$output <- lapply(spinupOutputs, function(tbl){
-    tbl$row_idx <- combinedOutputs$cohortGroupID
+    tbl <- as.data.table(tbl)
+    tbl[, row_idx := combinedOutputs$cohortGroupID]
     tbl <- unique(tbl)
-    tbl$row_idx <- NULL
-    tbl
+    tbl[, row_idx := NULL]
+    as.data.frame(tbl)
   })
   
   return(spinupOut)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -22,6 +22,7 @@ spadesTestPaths <- SpaDEStestSetUpDirectories()
 
 # Source the functions
 lapply(list.files(file.path(spadesTestPaths$RProj, "R"), full.names = TRUE), source)
+Require::Require(c("data.table", "terra"))
 
 # Install required packages
 withr::with_options(c(timeout = 600), Require::Install(

--- a/tests/testthat/test-4-LandRCBM_split3pools.R
+++ b/tests/testthat/test-4-LandRCBM_split3pools.R
@@ -147,7 +147,7 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   )
   # Run tests
   expect_s4_class(simTest, "simList")
-  
+
   # check all outputs are there
   expect_true(all(
     c("aboveGroundBiomass", "cbm_vars", "cohortDT", "cohortGroupKeep", "cohortGroups", "growth_increments", 


### PR DESCRIPTION
I fixed an error: In the last PR, DOM cohorts were not dropped at some point... 

I also create cohort groups for the spinup results. Cohorts are grouped the same species, age, and carbon aboveground and belowground. I tried rounding the belowground carbon to mg/ha, but it did not speed things up.

Live cohortGroups are defined as cohort that shares (1) the same increments (gcids) and (2) the same cohort groups in the last timestep. 

As before, DOM cohorts are grouped at the pixel-level (i.e.,1 DOM cohort per pixel). 

