### PR TITLE
Optimizing

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -736,7 +736,8 @@ UpdateCohortGroups <- function(sim){
     }
     missingCohorts[, gcids := 0]
     missingCohorts[, age := 0]
-    missingCohorts[, cohortGroupID := .GRP + max(cohorts$cohortGroupID, na.rm = TRUE), by = pixelIndex]
+    maxCohortGroupID <- max(cohorts$cohortGroupID, na.rm = TRUE)
+    missingCohorts[, cohortGroupID := .GRP + maxCohortGroupID, by = pixelIndex]
     cohorts[is.na(gcids), ] <- missingCohorts
   }
   

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -792,8 +792,8 @@ PrepareCBMvars <- function(sim){
     # Set live pools to 0 for DOM cohorts.
     new_cbm_pools[row_idx %in% sim$cohortGroups[gcids == 0, cohortGroupID], c("Merch", "Foliage", "Other", "CoarseRoots", "FineRoots") := 0L]
   }
-  new_cbm_pools <- unique(new_cbm_pools)
   setkey(new_cbm_pools, row_idx)
+  new_cbm_pools <- unique(new_cbm_pools, by = "row_idx")
   
   # 2. Prepare cbm flux
   # Get the flux of the cohorts of the previous timestep
@@ -816,8 +816,8 @@ PrepareCBMvars <- function(sim){
     flux_columns <- setdiff(colnames(new_cbm_flux), "row_idx")
     new_cbm_flux <- new_cbm_flux[, lapply(.SD, sum), by = row_idx, .SDcols = flux_columns]
   }
-  new_cbm_flux <- unique(new_cbm_flux)
   setkey(new_cbm_flux, row_idx)
+  new_cbm_flux <- unique(new_cbm_flux, by = "row_idx")
   
   # 3. Prepare cbm parameters
   # Get the mean annual temperature based on spatial unit.
@@ -891,7 +891,7 @@ PrepareCBMvars <- function(sim){
     new_cbm_state[row_idx %in% DOMcohorts, time_since_last_disturbance := 0]
     new_cbm_state[row_idx %in% DOMcohorts, time_since_land_use_change  := -1]
     new_cbm_state[row_idx %in% DOMcohorts, last_disturbance_type := -1]
-    new_cbm_state <- unique(new_cbm_state)
+    new_cbm_state <- unique(new_cbm_state, by = "row_idx")
   }
   
   # Set the state of the new cohorts
@@ -918,8 +918,8 @@ PrepareCBMvars <- function(sim){
       newCohorts_cbm_state
     )
   }
-  new_cbm_state <- unique(new_cbm_state)
   setkey(new_cbm_state, row_idx)
+  new_cbm_state <- unique(new_cbm_state, by = "row_idx")
   
   # 5. Put in cbm_vars
   cbm_vars <- list(

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -587,7 +587,7 @@ SplitYieldTables <- function(sim) {
                   by = c("yieldTableIndex", "speciesCode")]
   
   # 3.3. Link increments back to growth curve IDs (`gcids`).
-  map_gcid_yield <- unique(cohortDT, by = "yieldTableIndex")[, .(yieldTableIndex, speciesCode, gcids)]
+  map_gcid_yield <- unique(cohortDT, by = "gcids")[, .(yieldTableIndex, speciesCode, gcids)]
   sim$growth_increments <-  yieldIncrements[map_gcid_yield, 
                                             on = .(yieldTableIndex, speciesCode)]
   

--- a/R/splitCohortData.R
+++ b/R/splitCohortData.R
@@ -11,7 +11,7 @@ splitCohortData <- function(cohortData, pixelGroupMap, standDT, table6, table7){
   # New pixel group for unique combination of pixelGroup and CBM spatial units
   spatialDT[, newPixelGroup := .GRP, by = .(pixelGroup, spatial_unit_id)]
   # Add spatial information to cohortData
-  spatialUnits <- unique(spatialDT[, !("pixelIndex")])
+  spatialUnits <- unique(spatialDT, by = "newPixelGroup")[, !("pixelIndex")]
   allInfoCohortData <- addSpatialUnits(
     cohortData = cohortData,
     spatialUnits = spatialUnits

--- a/R/updateSpinupCohortGroups.R
+++ b/R/updateSpinupCohortGroups.R
@@ -17,7 +17,7 @@ updateSpinupCohortGroups <- function(spinupOut){
   spinupOut$output <- lapply(spinupOutputs, function(tbl){
     tbl <- as.data.table(tbl)
     tbl[, row_idx := combinedOutputs$cohortGroupID]
-    tbl <- unique(tbl)
+    tbl <- unique(tbl, by = "row_idx")
     tbl[, row_idx := NULL]
     as.data.frame(tbl)
   })


### PR DESCRIPTION
A few changes optimizing the algorithm. It is now significantly faster.

For reference, running RIA with `LandR` and `scfm` for 5 years (with data preparation and spinup cached) went from ~52 minutes to ~34 minutes. Considering, that it includes the time to run `LandR` and `scfm` and `cbm` annual event, I am confident that `LandRCBM_split3pools` is at least 2x faster, if not 3 or 4 times.
