### PR TITLE
Merchantability criteria

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -20,6 +20,8 @@ defineModule(sim, list(
     defineParameter("numPixGroupPlots", "integer", 10L, NA, NA,
                     "When plotting the yield curves, this is how many unique pixel groups will ",
                     "be randomly selected and plotted."),
+    defineParameter("minMerchantableAge", "integer", 15L, NA, NA,
+                    "Minimum age for which a cohort can have wood considered merchantable."),
     defineParameter(".plots", "character", "screen", NA, NA,
                     "Used by Plots function, which can be optionally used here"),
     defineParameter(".plotInitialTime", "numeric", start(sim), NA, NA,
@@ -100,6 +102,13 @@ defineModule(sim, list(
                    "but recalculated using total biomass (metric tonnes of tree biomass/ha)",
                    "instead of vol/ha."),
       sourceURL = "https://nfi.nfis.org/resources/biomass_models/appendix2_table7_tb.csv"
+    ),
+    expectsInput(
+      objectName = "tableMerchantability", objectClass = "data.table",
+      desc = paste("Parameters to estimate the proportion of stemwood that is merchantable,",
+                   "Estimated by approximating the relationship between stemwood biomass and",
+                   "nonmerchfactor predicted by equation 2 of Boudewyn et al., 2007."),
+      sourceURL = "https://drive.google.com/file/d/1wa2QMd7Eo-bPpfigchdpPPPxo7NVpPiC/view?usp=drive_link"
     ),
     expectsInput(
       objectName = "yieldTablesCumulative", objectClass = "data.table",
@@ -882,6 +891,14 @@ PrepareCBMvars <- function(sim){
                              destinationPath = inputPath(sim),
                              filename2 = "appendix2_table7_tb.csv",
                              overwrite = TRUE) |> Cache(userTags = "prepInputsTable7")
+  }
+  
+  if (!suppliedElsewhere("tableMerchantability", sim)) {
+    sim$table7 <- prepInputs(url = extractURL("tableMerchantability"),
+                             fun = "data.table::fread",
+                             destinationPath = inputPath(sim),
+                             filename2 = "merchantabilityParams.csv",
+                             overwrite = TRUE) |> Cache(userTags = "prepInputsTableMerch")
   }
   
   return(invisible(sim))

--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -902,7 +902,7 @@ PrepareCBMvars <- function(sim){
                              destinationPath = inputPath(sim),
                              filename2 = "merchantabilityParams.csv",
                              overwrite = TRUE) |> Cache(userTags = "prepInputsTableMerch")
-    sim$tableMerchantability <- cbind(sim$tableMerchantability, minAge = P(sim)minMerchantableAge)
+    sim$tableMerchantability <- cbind(sim$tableMerchantability, minAge = P(sim)$minMerchantableAge)
   }
   
   return(invisible(sim))

--- a/R/splitCohortData.R
+++ b/R/splitCohortData.R
@@ -1,4 +1,4 @@
-splitCohortData <- function(cohortData, pixelGroupMap, standDT, table6, table7){
+splitCohortData <- function(cohortData, pixelGroupMap, standDT, table6, table7, tableMerchantability){
   # Prepare cohort data for biomass splitting-----------------------------------
   # Match pixel group with jurisdiction and CBM spatial units
   spatialDT <- data.table(
@@ -31,7 +31,7 @@ splitCohortData <- function(cohortData, pixelGroupMap, standDT, table6, table7){
   cohortPools <- CBMutils::cumPoolsCreateAGB(allInfoAGBin = allInfoCohortData,
                                              table6 = table6,
                                              table7 = table7,
-                                             tableMerchantability = sim$tableMerchantability,
+                                             tableMerchantability = tableMerchantability,
                                              "pixelGroup")
   
   # Get pixel-level biomass data.-----------------------------------------------

--- a/R/splitCohortData.R
+++ b/R/splitCohortData.R
@@ -31,6 +31,7 @@ splitCohortData <- function(cohortData, pixelGroupMap, standDT, table6, table7){
   cohortPools <- CBMutils::cumPoolsCreateAGB(allInfoAGBin = allInfoCohortData,
                                              table6 = table6,
                                              table7 = table7,
+                                             tableMerchantability = sim$tableMerchantability,
                                              "pixelGroup")
   
   # Get pixel-level biomass data.-----------------------------------------------

--- a/tests/testthat/test-3-splitCohortData.R
+++ b/tests/testthat/test-3-splitCohortData.R
@@ -21,6 +21,11 @@ test_that("function to split cohortData works", {
   
   table6 <- fread("https://nfi.nfis.org/resources/biomass_models/appendix2_table6_tb.csv", showProgress = FALSE)
   table7 <- fread("https://nfi.nfis.org/resources/biomass_models/appendix2_table7_tb.csv", showProgress = FALSE)
+  tableMerch <- reproducible::prepInputs(url = "https://drive.google.com/file/d/1wa2QMd7Eo-bPpfigchdpPPPxo7NVpPiC/view?usp=drive_link",
+                                         fun = "data.table::fread",
+                                         destinationPath = spadesTestPaths$temp$inputs,
+                                         filename2 = "appendix2_table7_tb.csv")
+  tableMerch <- cbind(tableMerch, minAge = 15)
   
   # Check that it runs with no error
   expect_no_error({
@@ -29,7 +34,8 @@ test_that("function to split cohortData works", {
       pixelGroupMap = copy(pixelGroupMap),
       standDT = copy(standDT),
       table6 = copy(table6),
-      table7 = copy(table7)
+      table7 = copy(table7),
+      tableMerchantability = copy(tableMerch)
     )
   })
 
@@ -51,7 +57,8 @@ test_that("function to split cohortData works", {
     pixelGroupMap = copy(pixelGroupMap),
     standDT = copy(standDT),
     table6 = copy(table6),
-    table7 = copy(table7)
+    table7 = copy(table7),
+    tableMerchantability = copy(tableMerch)
   )
   
   # Calculate expected rows:
@@ -71,7 +78,8 @@ test_that("function to split cohortData works", {
     pixelGroupMap = copy(pixelGroupMap),
     standDT = copy(standDT),
     table6 = copy(table6), 
-    table7 = copy(table7)
+    table7 = copy(table7),
+    tableMerchantability = copy(tableMerch)
   )
   
   # Add total biomass column to result

--- a/tests/testthat/test-4-LandRCBM_split3pools.R
+++ b/tests/testthat/test-4-LandRCBM_split3pools.R
@@ -101,6 +101,9 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
         CBM_core = list(
           skipCohortGroupHandling = TRUE,
           skipPrepareCBMvars = TRUE
+        ),
+        Biomass_core = list(
+          .plots = NA
         )
       ),
       paths   = list(


### PR DESCRIPTION
See https://github.com/PredictiveEcology/CBMutils/pull/66 and #10 

For now, the table of fitted parameters is on the Carbon google drive. At some point, we might want to start from the raw Boudewyn table, extract the lines we want (species, ecozone and juris_id in study area), and fit the parameter to create the table as something done in the `.inputObjects()` step. It would be more transparent, and we would not rely on access to Google Drive. Anyway, this is a big first step.

The minimum age is a new parameter to the module. It sets what is the age for which a cohort can have merchantable stemwood. For now, it is the same for all species/ecolocation. By default it is 15 years (when age <= 15, all stemwood is "other wood").