### PR TITLE
DOM cohort test updates

### DIFF
--- a/tests/testthat/test-5-integration-LandRCBM.R
+++ b/tests/testthat/test-5-integration-LandRCBM.R
@@ -91,16 +91,13 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   expect_is(simTest$cbm_vars, "list")
   expect_named(simTest$cbm_vars, c("key", "pools", "flux", "parameters", "state"))
   NcohortGroups <- length(unique(simTest$cbm_vars$key$row_idx))
-  expect_equal(nrow(simTest$cbm_vars$pools), NcohortGroups)
-  expect_equal(simTest$cbm_vars$pools$Merch, simTest$aboveGroundBiomass$merch)
-  expect_equal(simTest$cbm_vars$pools$Foliage, simTest$aboveGroundBiomass$foliage)
-  expect_equal(simTest$cbm_vars$pools$Other, simTest$aboveGroundBiomass$other)
-  expect_equal(nrow(simTest$cbm_vars$flux), NcohortGroups)
+  expect_equal(nrow(simTest$cbm_vars$pools),      NcohortGroups)
+  expect_equal(nrow(simTest$cbm_vars$flux),       NcohortGroups)
   expect_equal(nrow(simTest$cbm_vars$parameters), NcohortGroups)
+  expect_equal(nrow(simTest$cbm_vars$state),      NcohortGroups)
   expect_equal(simTest$cbm_vars$parameters$merch_inc, simTest$gcIncrements$merch_inc)
   expect_equal(simTest$cbm_vars$parameters$foliage_inc, simTest$gcIncrements$foliage_inc)
   expect_equal(simTest$cbm_vars$parameters$other_inc, simTest$gcIncrements$other_inc)
-  expect_equal(nrow(simTest$cbm_vars$state), NcohortGroups)
   
   # check species types
   expect_in(simTest$cbm_vars$state[speciesCode == "Abie_las", sw_hw], 0L) # SW

--- a/tests/testthat/test-5-integration-LandRCBM.R
+++ b/tests/testthat/test-5-integration-LandRCBM.R
@@ -95,9 +95,6 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   expect_equal(nrow(simTest$cbm_vars$flux),       NcohortGroups)
   expect_equal(nrow(simTest$cbm_vars$parameters), NcohortGroups)
   expect_equal(nrow(simTest$cbm_vars$state),      NcohortGroups)
-  expect_equal(simTest$cbm_vars$parameters$merch_inc, simTest$gcIncrements$merch_inc)
-  expect_equal(simTest$cbm_vars$parameters$foliage_inc, simTest$gcIncrements$foliage_inc)
-  expect_equal(simTest$cbm_vars$parameters$other_inc, simTest$gcIncrements$other_inc)
   
   # check species types
   expect_in(simTest$cbm_vars$state[speciesCode == "Abie_las", sw_hw], 0L) # SW
@@ -108,6 +105,11 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   
   # checks for "active" cohorts
   ActiveCohortGroups <- simTest$cbm_vars$state[gcID != 0, row_idx]
+  
+  expect_equal(
+    simTest$cbm_vars$parameters[ActiveCohortGroups, .(merch_inc, foliage_inc, other_inc)],
+    simTest$gcIncrements[, .(merch_inc, foliage_inc, other_inc)]
+  )
   expect_equal(
     simTest$aboveGroundBiomass[,.(Merch = merch, Foliage = foliage, Other = other)],
     simTest$cbm_vars$pools[ActiveCohortGroups,.(Merch, Foliage, Other)]

--- a/tests/testthat/test-5-integration-LandRCBM.R
+++ b/tests/testthat/test-5-integration-LandRCBM.R
@@ -123,7 +123,7 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   DOMCohortGroups  = simTest$cbm_vars$state[gcID == 0, row_idx]
   # DOM cohort groups have 0 above ground biomass
   expect_true(
-    all(simTest$cbm_vars$pools[DOMCohortGroups, .(Merch, Foliage, Other)] == 0)
+    all(round(simTest$cbm_vars$pools[DOMCohortGroups, .(Merch, Foliage, Other)], 10^-12) == 0)
   )
   # There can't be more than 1 DOM cohort groups per pixel
   expect_equal(


### PR DESCRIPTION
Made a couple changes to the integration test assertions where I was finding there were issues when DOM cohorts happened to be present. I'm finding that they sometimes are and something aren't with this test.

1. [test assertion that DOM cohorts have 0 AGB allows small amounts of biomass](https://github.com/PredictiveEcology/LandRCBM_split3pools/commit/592e76e6987e6b2c1c3f0f8509539cb8b8ea7fde)

I am finding that DOM cohorts sometimes have very small values in the `Merch`, `Foliage`, or `Other` pools so I updated the check to allow values less than 10^-12 in those columns.

2. [test assertion for active cohorts moved to active cohorts section](https://github.com/PredictiveEcology/LandRCBM_split3pools/commit/44c40f857200cefc7bb8b25121df47ef1fd93ff5)

`simTest$gcIncrements` doesn't include increments for DOM cohorts so I've moved this check to only apply to active cohorts.

3. [duplicate test assertion removed](https://github.com/PredictiveEcology/LandRCBM_split3pools/commit/d0f36ddf8a303b58bd7f072f7e209d301191a276)

These assertions are identical to this one below it: https://github.com/PredictiveEcology/LandRCBM_split3pools/blob/623604835d86c414a39604a4cf2090abf733524d/tests/testthat/test-5-integration-LandRCBM.R#L114
