### PR TITLE
Test check helper function added

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -697,7 +697,7 @@ UpdateCohortGroups <- function(sim){
     all.y = TRUE,
     sort = FALSE
   ) |> unique()
-  setkey(sim$cbm_vars$key, row_idx)
+  setkey(sim$cbm_vars$key, cohortID)
   
   # Update cbm_vars state.
   sim$cbm_vars$state <- merge(

--- a/tests/testthat/helper-checks.R
+++ b/tests/testthat/helper-checks.R
@@ -1,0 +1,122 @@
+
+# Helper function: check structure of output objects
+# @param spinup logical. Checks match expected state after the spinup.
+check_module_outputs <- function(simTest, spinup = FALSE){
+  
+  # yieldTablesId
+  expect_is(simTest$yieldTablesId, "data.table")
+  expect_in(c("pixelIndex", "yieldTableIndex"), 
+            names(simTest$yieldTablesId))
+  
+  # yieldTablesCumulative
+  expect_is(simTest$yieldTablesCumulative, "data.table")
+  expect_in(c("speciesCode", "age", "yieldTableIndex", "merch", "foliage", "other"),
+            names(simTest$yieldTablesCumulative))
+  
+  expect_true(all(simTest$yieldTablesCumulative$yieldTableIndex %in% simTest$yieldTablesId$yieldTableIndex))
+  
+  # gcMeta
+  expect_is(simTest$gcMeta, "data.table")
+  expect_in(c("gcID", "speciesCode", "sw"),
+            names(simTest$gcMeta))
+  
+  # gcIncrements
+  expect_is(simTest$gcIncrements, "data.table")
+  expect_in(
+    c("gcID", "age", "merch_inc", "foliage_inc", "other_inc"),
+    names(simTest$gcIncrements))
+  expect_setequal(simTest$gcIncrements$gcID, simTest$gcMeta$gcID)
+  
+  if (spinup){
+    expect_in("yieldTableIndex", names(simTest$gcIncrements))
+    expect_equal(nrow(simTest$gcIncrements), nrow(simTest$yieldTablesCumulative))
+    expect_true(all(simTest$gcIncrements$yieldTableIndex %in% simTest$yieldTablesId$yieldTableIndex))
+    
+  }else{
+    expect_setequal(simTest$gcIncrements$gcID, simTest$gcMeta$gcID)
+    expect_equal(nrow(simTest$gcIncrements), nrow(simTest$gcMeta))
+  }
+  
+  # cohortDT
+  expect_is(simTest$cohortDT, "data.table")
+  expect_in(c("cohortID", "pixelIndex", "age", "speciesCode", "gcID"),
+            names(simTest$cohortDT))
+  
+  expect_true(all(simTest$cohortDT$gcID %in% simTest$gcMeta$gcID))
+  
+  # abovegroundbiomass
+  expect_is(simTest$aboveGroundBiomass, "data.table")
+  expect_in(c("pixelIndex", "speciesCode", "age", "merch", "foliage", "other"), 
+            names(simTest$aboveGroundBiomass))
+  
+  ## check that total biomass per species match cohortData
+  expectedSpeciesB <- simTest$cohortData[, .(total_biomass = sum(B)/200), by = speciesCode]
+  resultSpeciesB <- copy(simTest$aboveGroundBiomass)[, B := merch + foliage + other]
+  resultSpeciesB <- resultSpeciesB[, .(total_biomass = sum(B)), by = speciesCode]
+  expect_equal(expectedSpeciesB[order(speciesCode)], resultSpeciesB[order(speciesCode)])
+  
+  # summaryAGB
+  if (!spinup){
+    
+    expect_is(simTest$summaryAGB, "data.table")
+    expect_in(
+      c("speciesCode", "merch", "foliage", "other", "year"),
+      names(simTest$summaryAGB))
+    expect_equal(simTest$summaryAGB$year, do.call(c, lapply(start(simTest):end(simTest), rep, 2)))
+  }
+  
+  # cbm_vars
+  if ("CBM_core" %in% modules(simTest)){
+    check_cbm_vars(simTest)
+  }
+}
+
+
+# Helper function: check cbm_vars
+check_cbm_vars <- function(simTest){
+  
+  expect_is(simTest$cbm_vars, "list")
+  expect_setequal(names(simTest$cbm_vars), c("key", "parameters", "state", "pools", "flux"))
+  expect_equal(data.table::key(simTest$cbm_vars$key), "cohortID")
+  for (table in c("parameters", "state", "pools", "flux")){
+    expect_equal(data.table::key(simTest$cbm_vars[[table]]), "row_idx")
+  }
+  
+  expect_is(simTest$cbm_vars$key, "data.table")
+  expect_in(c("cohortID", "pixelIndex", "row_idx"), names(simTest$cbm_vars$key))
+  
+  # check table row counts
+  NcohortGroups <- length(unique(simTest$cbm_vars$key$row_idx))
+  expect_equal(nrow(simTest$cbm_vars$parameters), NcohortGroups)
+  expect_equal(nrow(simTest$cbm_vars$state),      NcohortGroups)
+  expect_equal(nrow(simTest$cbm_vars$pools),      NcohortGroups)
+  expect_equal(nrow(simTest$cbm_vars$flux),       NcohortGroups)
+  
+  # checks for "active" cohorts
+  row_idx_active <- simTest$cbm_vars$state$gcID != 0
+  ActiveCohortGroups <- simTest$cbm_vars$key[row_idx %in% which(row_idx_active), row_idx]
+  
+  expect_equal(
+    simTest$cbm_vars$state[ActiveCohortGroups, age],
+    simTest$aboveGroundBiomass$age
+  )
+  expect_equal(
+    simTest$cbm_vars$pools[ActiveCohortGroups, .(Merch, Foliage, Other)],
+    simTest$aboveGroundBiomass[,.(Merch = merch, Foliage = foliage, Other = other)]
+  )
+
+  # checks for DOM cohorts
+  DOMCohortGroups <- simTest$cbm_vars$key[row_idx %in% which(!row_idx_active), row_idx]
+
+  ## DOM cohort groups have 0 above ground biomass
+  expect_true(
+    all(round(simTest$cbm_vars$pools[DOMCohortGroups, .(Merch, Foliage, Other)], 10^-12) == 0)
+  )
+
+  ## There can't be more than 1 DOM cohort groups per pixel
+  expect_equal(
+    length(DOMCohortGroups),
+    nrow(simTest$cbm_vars$key[row_idx %in% DOMCohortGroups])
+  )
+}
+

--- a/tests/testthat/test-4-LandRCBM_split3pools.R
+++ b/tests/testthat/test-4-LandRCBM_split3pools.R
@@ -7,7 +7,7 @@ test_that("module runs as a standAlone when not dynamic", {
   
   simInitTest <- simInit(
     modules = "LandRCBM_split3pools",
-    times   = list(start = 2000, end = 2021),
+    times   = list(start = 2000, end = 2000),
     paths   = list(
       modulePath  = spadesTestPaths$modulePath,
       inputPath   = spadesTestPaths$inputPath,
@@ -32,41 +32,12 @@ test_that("module runs as a standAlone when not dynamic", {
                     events = list("LandRCBM_split3pools" = c("init", "splitInit")))
   expect_s4_class(simTest, "simList")
   
-  # check abovegroundbiomass
-  expect_is(simTest$aboveGroundBiomass, "data.table")
-  expect_named(simTest$aboveGroundBiomass, c("pixelIndex", "speciesCode", "age", "merch", "foliage", "other"))
-  # check that total biomass per species match cohortData
-  expectedSpeciesB <- simTest$cohortData[, .(total_biomass = sum(B)/200), by = speciesCode]
-  resultSpeciesB <- copy(simTest$aboveGroundBiomass)[, B := merch + foliage + other]
-  resultSpeciesB <- resultSpeciesB[, .(total_biomass = sum(B)), by = speciesCode]
-  expect_equal(expectedSpeciesB, resultSpeciesB)
-  
-  # check cohortDT
-  expect_is(simTest$cohortDT, "data.table")
-  expect_named(simTest$cohortDT, c("cohortID", "pixelIndex", "age", "speciesCode", "gcID"))
-  expect_true(all(simTest$cohortDT$age %in% simTest$cohortData$age))
-  
-  # check gcMeta
-  expect_is(simTest$gcMeta, "data.table")
-  expect_named(simTest$gcMeta, c("gcID", "speciesCode", "sw"))
-  expect_true(all(simTest$cohortDT$gcID %in% simTest$gcMeta$gcID))
-  
-  # check gcIncrements
-  expect_is(simTest$gcIncrements, "data.table")
-  expect_named(simTest$gcIncrements, c("gcID", "yieldTableIndex", "age", "merch_inc", "foliage_inc", "other_inc"))
-  expect_true(all(simTest$gcIncrements$gcID %in% simTest$gcMeta$gcID))
-  expect_true(all(simTest$gcIncrements$yieldTableIndex %in% simTest$yieldTablesId$yieldTableIndex))
+  # check output object structure
+  check_module_outputs(simTest, spinup = TRUE)
   
   # check yieldTablesCumulative
-  expect_is(simTest$yieldTablesCumulative, "data.table")
-  expect_named(simTest$yieldTablesCumulative, c("speciesCode", "age", "yieldTableIndex", "merch", "foliage", "other"))
   preLandRCBM_ytc <- file.path(spadesTestPaths$testdata, "LandR", "yieldTablesCumulative.csv") |> data.table::fread()
   expect_equal(nrow(simTest$yieldTablesCumulative), nrow(preLandRCBM_ytc))
-  expect_true(all(simTest$yieldTablesCumulative$yieldTableIndex %in% simTest$yieldTablesId$yieldTableIndex))
-  
-  # check yieldTablesId
-  expect_is(simTest$yieldTablesId, "data.table")
-  expect_named(simTest$yieldTablesId, c("pixelIndex", "yieldTableIndex"))
 
 })
 

--- a/tests/testthat/test-5-integration-LandRCBM.R
+++ b/tests/testthat/test-5-integration-LandRCBM.R
@@ -30,7 +30,6 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
       ),
       CBM_core = list(
         .plot = FALSE,
-        skipCohortGroupHandling = TRUE,
         skipPrepareCBMvars = TRUE
       ),
       Biomass_core = list(
@@ -64,104 +63,6 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   # Run spades
   simTest <- SpaDES.core::spades(simTestInit)
   expect_s4_class(simTest, "simList")
-  
-  # check all outputs are there
-  expect_true(all(
-    c("aboveGroundBiomass", "cbm_vars", "cohortDT", "gcIncrements", "gcMeta", 
-      "summaryAGB", "yieldTablesCumulative", "yieldTablesId") %in%
-      names(simTest)
-  ))
-  
-  # check aboveGroundBiomass
-  expect_is(simTest$aboveGroundBiomass, "data.table")
-  expect_named(simTest$aboveGroundBiomass,
-               c("pixelIndex", "speciesCode", "age", "merch", "foliage", "other"),
-               ignore.order = TRUE)
-  # check that total biomass per species match cohortData
-  expectedSpeciesB <- simTest$cohortData[, .(total_biomass = sum(B)/200), by = speciesCode]
-  resultSpeciesB <- copy(simTest$aboveGroundBiomass)[, B := merch + foliage + other]
-  resultSpeciesB <- resultSpeciesB[, .(total_biomass = sum(B)), by = speciesCode]
-  expect_equal(expectedSpeciesB, resultSpeciesB)
-  
-  # check cbm_vars key
-  expect_is(simTest$cbm_vars$key, "data.table")
-  expect_named(simTest$cbm_vars$key, c("pixelIndex", "row_idx_prev", "cohortID", "row_idx", "disturbance_type_id"), ignore.order = TRUE)
-  
-  # check cbm_vars
-  expect_is(simTest$cbm_vars, "list")
-  expect_named(simTest$cbm_vars, c("key", "pools", "flux", "parameters", "state"))
-  NcohortGroups <- length(unique(simTest$cbm_vars$key$row_idx))
-  expect_equal(nrow(simTest$cbm_vars$pools), NcohortGroups)
-  expect_equal(simTest$cbm_vars$pools$Merch, simTest$aboveGroundBiomass$merch)
-  expect_equal(simTest$cbm_vars$pools$Foliage, simTest$aboveGroundBiomass$foliage)
-  expect_equal(simTest$cbm_vars$pools$Other, simTest$aboveGroundBiomass$other)
-  expect_equal(nrow(simTest$cbm_vars$flux), NcohortGroups)
-  expect_equal(nrow(simTest$cbm_vars$parameters), NcohortGroups)
-  expect_equal(simTest$cbm_vars$parameters$merch_inc, simTest$gcIncrements$merch_inc)
-  expect_equal(simTest$cbm_vars$parameters$foliage_inc, simTest$gcIncrements$foliage_inc)
-  expect_equal(simTest$cbm_vars$parameters$other_inc, simTest$gcIncrements$other_inc)
-  expect_equal(nrow(simTest$cbm_vars$state), NcohortGroups)
-  
-  # check species types
-  expect_in(simTest$cbm_vars$state[speciesCode == "Abie_las", sw_hw], 0L) # SW
-  expect_in(simTest$cbm_vars$state[speciesCode == "Pinu_con", sw_hw], 0L) # SW
-  
-  # spatial unit id is correct
-  expect_true(all(simTest$cbm_vars$state$spatial_unit_id == 42))
-  
-  # checks for "active" cohorts
-  ActiveCohortGroups <- simTest$cbm_vars$state[gcID != 0, row_idx]
-  expect_equal(
-    simTest$aboveGroundBiomass[,.(Merch = merch, Foliage = foliage, Other = other)],
-    simTest$cbm_vars$pools[ActiveCohortGroups,.(Merch, Foliage, Other)]
-  )
-  expect_equal(
-    simTest$aboveGroundBiomass$age,
-    simTest$cbm_vars$state$age[ActiveCohortGroups]
-  )
-  
-  # checks for DOM cohorts (there are none in this test)
-  DOMCohortGroups  = simTest$cbm_vars$state[gcID == 0, row_idx]
-  # DOM cohort groups have 0 above ground biomass
-  expect_true(
-    all(simTest$cbm_vars$pools[DOMCohortGroups, .(Merch, Foliage, Other)] == 0)
-  )
-  # There can't be more than 1 DOM cohort groups per pixel
-  expect_equal(
-    length(DOMCohortGroups),
-    nrow(simTest$cbm_vars$key[row_idx %in% DOMCohortGroups])
-  )
-  
-  # check cohortDT
-  expect_is(simTest$cohortDT, "data.table")
-  expect_named(simTest$cohortDT,
-               c("cohortID", "pixelIndex", "age", "speciesCode", "sw", "gcID"),
-               ignore.order = TRUE)
-  expect_setequal(simTest$cohortDT$gcID, simTest$cohortDT$cohortID)
-  
-  # check gcIncrements
-  expect_is(simTest$gcIncrements, "data.table")
-  expect_named(simTest$gcIncrements,
-               c("gcID", "age", "merch_inc", "foliage_inc", "other_inc"),
-               ignore.order = TRUE)
-  expect_equal(nrow(simTest$gcIncrements), nrow(simTest$cohortDT))
-  expect_setequal(simTest$cohortDT$gcID, simTest$gcIncrements$gcID)
-  
-  # check gcMeta
-  expect_is(simTest$gcMeta, "data.table")
-  expect_named(simTest$gcMeta, 
-               c("gcID", "speciesCode", "sw"))
-  expect_equal(nrow(simTest$gcMeta), nrow(simTest$gcIncrements))
-  expect_setequal(simTest$gcMeta$gcID, simTest$gcIncrements$gcID)
-  
-  # check summaryAGB
-  expect_is(simTest$summaryAGB, "data.table")
-  expect_named(
-    simTest$summaryAGB, 
-    c("speciesCode", "merch", "foliage", "other", "year"),
-    ignore.order = TRUE
-  )
-  expect_equal(simTest$summaryAGB$year, do.call(c, lapply(times$start:times$end, rep, 2)))
   
   ## Check event order
   completedEvents <- completed(simTest)
@@ -205,4 +106,14 @@ test_that("module runs with Biomass_core and CBM_core when dynamic", {
   realizedEventOrder <- completedEvents[eventTime == end(simTest) & eventType %in% eventsToCheck]
   expect_equal(expectedEventOrder, realizedEventOrder$eventType)
   
+  # check output object structure
+  check_module_outputs(simTest)
+  
+  # check cbm_vars
+  expect_in(simTest$cbm_vars$state[speciesCode == "Abie_las", sw_hw], 0L) # SW
+  expect_in(simTest$cbm_vars$state[speciesCode == "Pinu_con", sw_hw], 0L) # SW
+  
+  expect_true(all(simTest$cbm_vars$state$spatial_unit_id == 42))
+  
 })
+


### PR DESCRIPTION
Set as a draft because this includes the changes introduced in open PR #58.

This adds a new helper function `check_module_outputs` to be used by the module tests. This checks that the output objects exist in the expected structure: they are of the expected class, they have the expected column names, and any other assertions that would always be true with any run of the module.

The assertions in this function are merged from existing checks in the [test-4-LandRCBM_split3pools.R](https://github.com/PredictiveEcology/LandRCBM_split3pools/blob/main/tests/testthat/test-4-LandRCBM_split3pools.R) and [test-5-integration-LandRCBM](https://github.com/PredictiveEcology/LandRCBM_split3pools/blob/main/tests/testthat/test-5-integration-LandRCBM) tests. Both of these tests now instead call this function to check the structure of the outputs and then have some additional assertions that apply specifically to those tests.

My motivation to do this is that next I will PR 4 module tests that check that growth, DOM cohorts, and new cohorts are handled correctly individually and each will benefit from running through these same set of standard checks. It's still easy to run everything the test checks line by line when interactively debugging which is helpful.

I'm also PRing a small change that sets the [sim$cbm_vars$key set to cohortID](https://github.com/PredictiveEcology/LandRCBM_split3pools/commit/3041cbf0234faf1cb9a904ab2a2201d790332125) since it makes the checking of the `cbm_vars` structure a bit easier.

@DominiqueCaron would you be able to look over the `check_module_outputs` assertions [tests/testthat/helper-checks.R](https://github.com/PredictiveEcology/LandRCBM_split3pools/blob/suz-test/tests/testthat/helper-checks.R) to make sure these are correct? This is essentially your existing code, but sometimes it has been rewritten in a way that makes it more flexible for checking the outputs whether the module is post-spinup or post-annual step since some outputs are a bit different depending on this.