### PR TITLE
yieldTablesCumulative and yieldTablesId removed from module outputs

### DIFF
--- a/LandRCBM_split3pools.R
+++ b/LandRCBM_split3pools.R
@@ -169,17 +169,6 @@ defineModule(sim, list(
       desc = paste("Sum of carbon mass for each species and above ground", 
                    "pool at each timestep across the landscape. Columns are `year`,",
                    "`speciesCode`, `merch`, `foliage`, `other`.")
-    ),
-    createsOutput(
-      objectName = "yieldTablesCumulative",
-      objectClass = "data.table",
-      desc = paste("Yield tables divided into above ground pools. Columns are",
-                   "`yieldTableIndex`, `age`, `speciesCode`, `merch`, `foliage`, `other`.)")
-    ),
-    createsOutput(
-      objectName = "yieldTablesId",
-      objectClass = "data.table",
-      desc = paste("A data.table linking spatially the yield tables. Columns are `pixelIndex` and `yieldTableIndex`.")
     )
   )
 ))
@@ -393,14 +382,10 @@ PlotYieldTables <- function(sim){
   } 
   pixGroupToPlot <- sample(unique(sim$yieldTablesId$yieldTableIndex), nPlots)
   
-  # dt for plotting.
-  plot_dt <- sim$yieldTablesCumulative[yieldTableIndex %in% pixGroupToPlot]
-  plot_dt[, totB := merch + foliage + other]
-  
   mod$yieldTableIndexPlotted <- pixGroupToPlot
   
   # plot
-  Plots(plot_dt, 
+  Plots(sim$yieldTablesCumulative[yieldTableIndex %in% pixGroupToPlot], 
         fn = gg_yieldCurves,
         types = P(sim)$.plots,
         filename = paste("yieldCurves"),
@@ -414,61 +399,24 @@ SplitYieldTables <- function(sim) {
   # Link yield curve IDs (yieldTableIndex) to CBM spatial units 
   # and generate initial cohort/stand data structures.
   
-  # 1.1. Match pixel-level yield table indices with CBM spatial units.
-  #      `spatialMatch` creates a data.table linking yieldTableIndex, ecozone, 
-  #      and jurisdiction.
-  #      `na.omit` removes pixels not forested.
-  spatialDT <- merge(
-    sim$standDT,
-    sim$yieldTablesId) |> na.omit()
-  # Ensure spatial matching produced results
-  if (nrow(spatialDT) == 0) {
-    stop("Spatial matching between yieldTablesId, standDT failed.")
-  }
-  
-  # 1.2. Create a new, unique ID for each unique combination of original yield 
-  #      table index and CBM spatial units. This handles cases
-  #      where one yield curve spans multiple ecozones/jurisdictions.
-  setorderv(spatialDT, cols = c("yieldTableIndex", "admin_abbrev", "eco_id"))
-  spatialDT[, newytid := .GRP, by = .(yieldTableIndex, admin_abbrev, eco_id)]
-  
-  # 1.3. Update the pixel-level yield table mapping (`sim$yieldTablesId`) to use
-  #      the new yield table ids. 
-  sim$yieldTablesId <- spatialDT[, .(pixelIndex, yieldTableIndex = newytid)] 
-  
   # 1.4. Generate the cohort-level attributes (`cohortDT`).
   #      This links individual cohorts (pixelGroup x species combinations)
   #      to their corresponding growth curve IDs (`gcID`).
-  #      Requires the original pixelGroupMap and the updated yieldTablesId.
-  cohortDT <- generateCohortDT(sim$cohortData, sim$pixelGroupMap, sim$yieldTablesId)
-  # Ensure cohort generation worked
-  if (is.null(cohortDT) || nrow(cohortDT) == 0) {
-    stop("generateCohortDT failed.")
-  }
+  cohortDT <- generateCohortDT(sim$cohortData, sim$pixelGroupMap, sim$standDT, sim$yieldTablesId)
   
-  # 1.5. Store essential cohort information (cohortID, pixelIndex, age, gcID) in simList.
+  # 1.2. Store essential cohort information in simList.
   sim$cohortDT <- cohortDT[, .(cohortID, pixelIndex, age, speciesCode, gcID)]
   
-  # 1.6. Create and store metadata about growth curves (`sim$gcMeta`).
+  # 1.3. Create and store metadata about growth curves (`sim$gcMeta`).
   #      Links gcID to species information.
-  sim$gcMeta <- unique(cohortDT, by = "gcID")[, .(gcID, speciesCode, sw)]
+  sim$gcMeta <- unique(cohortDT[, .(gcID, admin_abbrev, eco_id, yieldTableIndex, speciesCode)])
+  sim$gcMeta <- addForestType(sim$gcMeta)
+  sim$gcMeta <- addSpeciesCode(sim$gcMeta, "CanfiCode")
+  data.table::setnames(sim$gcMeta, "newCode", "CanfiCode")
+  setkey(sim$gcMeta, gcID)
+  setcolorder(sim$gcMeta)
   
-  # 1.8. Prepare yield table data (`sim$yieldTablesCumulative`) for biomass pool splitting.
-  #      Get unique combinations of original yieldTableIndex and spatial units.
-  spatialUnits <- unique(spatialDT, by = c("yieldTableIndex", "newytid", "admin_abbrev", "eco_id"))[, .(yieldTableIndex, newytid, admin_abbrev, eco_id)]
-  # Add these unique spatial units to the raw yield curves.
-  allInfoYieldTables <- addSpatialUnits(
-    cohortData = sim$yieldTablesCumulative,
-    spatialUnits = spatialUnits
-  )
-  # Add species codes (e.g., CanfiCode)
-  allInfoYieldTables <- addSpeciesCode(
-    cohortData = allInfoYieldTables,
-    code = "CanfiCode"
-  )
-  setnames(allInfoYieldTables, 
-           old = c("newCode", "eco_id", "admin_abbrev"), 
-           new = c("canfi_species", "ecozone", "juris_id"))
+  rm(cohortDT)
   
   # Step 2: Splitting AGB Curves into CBM Pools --------------------------------
   # Convert the total Above-Ground Biomass (AGB) yield curves into cumulative biomass
@@ -476,7 +424,14 @@ SplitYieldTables <- function(sim) {
   
   # 2.1. Prepare table for CBM pool splitting function.
   #      Rename the primary biomass column to 'B' as expected by CBMutils.
-  setnames(allInfoYieldTables, c("biomass"), c("B"))
+  allInfoYieldTables <- merge(
+    sim$gcMeta, 
+    sim$yieldTablesCumulative[, .(yieldTableIndex, speciesCode, age, biomass)], 
+    by = c("speciesCode", "yieldTableIndex"))
+  setnames(allInfoYieldTables,
+           old = c("admin_abbrev", "eco_id",  "CanfiCode",     "biomass"),
+           new = c("juris_id",     "ecozone", "canfi_species", "B"))
+  
   # Convert biomass units from g/m^2 to tonnes/ha: 1 g/m^2 = 0.01 tonnes/ha
   allInfoYieldTables[, B := B / 100]
   
@@ -487,30 +442,21 @@ SplitYieldTables <- function(sim) {
                                           table6 = sim$table6,
                                           table7 = sim$table7,
                                           tableMerchantability = sim$tableMerchantability,
-                                          pixGroupCol = "yieldTableIndex")
+                                          pixGroupCol = "gcID")
+  cumPools[, speciesCode := NULL]
   
   # 2.3. Ensure annual resolution by filling missing ages (especially age 0).
-  minAgeDT <- cumPools[,.(minAge = max(0L, min(age) - 1L)), by = c("yieldTableIndex", "speciesCode")]
+  minAgeDT <- cumPools[,.(minAge = max(0L, min(age) - 1L)), by = "gcID"]
   # Create sequences from 0 up to (but not including) the minimum age found.
   # Filter out cases where minAge is already 0.
-  fillAgesDT <-  minAgeDT[,.(age = seq(from = 0, to = minAge, by = 1)), 
-                          by = c("yieldTableIndex", "speciesCode")]
+  fillAgesDT <-  minAgeDT[,.(age = seq(from = 0, to = minAge, by = 1)), by = "gcID"]
   # Only proceed if there are ages to fill
   if (nrow(fillAgesDT) > 0) {
     # Create a table with the missing ages and zero biomass for all pools.
-    zeroBiomassDT <- fillAgesDT[, .(merch = 0, foliage = 0, other = 0),
-                                by = .(yieldTableIndex, speciesCode, age)] 
+    zeroBiomassDT <- fillAgesDT[, .(merch = 0, foliage = 0, other = 0), by = .(gcID, age)] 
     
     # Combine the original curves with the filled zero-biomass ages.
-    sim$yieldTablesCumulative <- rbindlist(list(cumPools, zeroBiomassDT), use.names = TRUE)
-    
-    # Ensure final table is ordered correctly.
-    setorderv(sim$yieldTablesCumulative, c("yieldTableIndex", "speciesCode", "age")) 
-  } else {
-    # If no filling needed, just assign the calculated pools
-    sim$yieldTablesCumulative <- cumPools
-    # Ensure order just in case
-    setorderv(sim$yieldTablesCumulative, c("yieldTableIndex", "speciesCode", "age")) 
+    cumPools <- rbindlist(list(cumPools, zeroBiomassDT), use.names = TRUE)
   }
   
   # Step 3: Calculating Annual Increments --------------------------------------
@@ -522,20 +468,11 @@ SplitYieldTables <- function(sim) {
   incCols <- c("merch_inc", "foliage_inc", "other_inc")
   
   # 3.2. Calculate increments using `diff`.
-  # `copy()` is necessary here because we need the cumulative values later,
-  # and the increment calculation modifies the table using `:=`.
-  yieldIncrements <- copy(sim$yieldTablesCumulative)
-  # Calculate difference between successive rows within each group.
-  yieldIncrements[, (incCols) := lapply(.SD, function(x) c(NA, diff(x))), .SDcols = poolCols,
-                  by = c("yieldTableIndex", "speciesCode")]
+  setkey(cumPools, gcID, age)
+  cumPools[, (incCols) := lapply(.SD, function(x) c(NA, diff(x))), .SDcols = poolCols, by = "gcID"]
   
-  # 3.3. Link increments back to growth curve IDs (`gcID`).
-  map_gcid_yield <- unique(cohortDT, by = "gcID")[, .(yieldTableIndex, speciesCode, gcID)]
-  sim$gcIncrements <-  yieldIncrements[map_gcid_yield, 
-                                       on = .(yieldTableIndex, speciesCode)]
-  
-  # 3.4. Final selection and ordering of columns for `sim$gcIncrements`.
-  sim$gcIncrements <- sim$gcIncrements[,.(gcID, yieldTableIndex, age, merch_inc, foliage_inc, other_inc)]
+  # 3.3. Final selection and ordering of columns for `sim$gcIncrements`.
+  sim$gcIncrements <- cumPools[,.(gcID, age, merch, foliage, other, merch_inc, foliage_inc, other_inc)]
   
   return(invisible(sim))
 }
@@ -546,15 +483,17 @@ PlotYieldTablesPools <- function(sim){
   
   # We want to plot the same cohorts across figures
   pixGroupToPlot <- mod$yieldTableIndexPlotted
-  plot_dt <- sim$yieldTablesCumulative[yieldTableIndex %in% pixGroupToPlot]
+  yieldTablePools <- sim$gcIncrements[sim$gcMeta, on = "gcID"][yieldTableIndex %in% pixGroupToPlot]
+  
+  # plot total yield curves
   plot_dt <- melt(
-    plot_dt, 
+    yieldTablePools, 
     id.vars = c("yieldTableIndex", "speciesCode", "age"),
     measure.vars = c("merch", "foliage", "other"),
     variable.name = "pool",
     value.name = "B"
   )
-  # plot total yield curves
+  
   Plots(plot_dt, 
         fn = gg_yieldCurvesPools,
         types = P(sim)$.plots,
@@ -563,16 +502,14 @@ PlotYieldTablesPools <- function(sim){
   )
   
   # plot increments
-  plot_dt <- sim$gcIncrements[yieldTableIndex %in% pixGroupToPlot]
   plot_dt <- melt(
-    plot_dt, 
-    id.vars = c("yieldTableIndex", "age", "gcID"),
+    yieldTablePools, 
+    id.vars = c("yieldTableIndex", "age", "speciesCode", "gcID"),
     measure.vars = c("merch_inc", "foliage_inc", "other_inc"),
     variable.name = "pool",
     value.name = "B"
   )
   plot_dt <- plot_dt[plot_dt$age > 0,]
-  plot_dt <- sim$gcMeta[plot_dt, on = "gcID"]
   Plots(plot_dt, 
         fn = gg_yieldCurvesPools,
         types = P(sim)$.plots,
@@ -632,12 +569,11 @@ AnnualIncrements <- function(sim){
   groupCols <- c("speciesCode", "age", "merch_inc", "foliage_inc", "other_inc")
   incrementsDT[, gcID := .GRP, by = groupCols]
   incrementsDT[, cohortID := .I]
-  # Add forest type ("sw" or "hw") for gcMeta
-  incrementsDT <- addForestType(incrementsDT)
   # Create data.table with cohort-level information
-  sim$cohortDT <- incrementsDT[, .(cohortID, pixelIndex, age, speciesCode, sw, gcID)]
+  sim$cohortDT <- incrementsDT[, .(cohortID, pixelIndex, age, speciesCode, gcID)]
   # Create data.table with growth curve-level information
-  sim$gcMeta <- unique(incrementsDT, by = "gcID")[, .(gcID, speciesCode, sw)]
+  sim$gcMeta <- unique(incrementsDT, by = "gcID")[, .(gcID, speciesCode)]
+  sim$gcMeta <- addForestType(sim$gcMeta)
   # Create final growth increment data.table
   sim$gcIncrements <- unique(incrementsDT, by = "gcID")[, .(gcID, age, merch_inc, foliage_inc, other_inc)]
   setkey(sim$gcIncrements, gcID)
@@ -661,7 +597,7 @@ UpdateCohortGroups <- function(sim){
   # Match the cohorts based on pixel, age, and species.
   cohorts <- merge(
     cohortsPrev,
-    sim$cohortDT[, .(pixelIndex, age, gcID, speciesCode, sw, cohortID)],
+    sim$cohortDT[, .(pixelIndex, age, gcID, speciesCode, cohortID)],
     by = c("pixelIndex", "age", "speciesCode"),
     all = TRUE,
     allow.cartesian = TRUE,
@@ -701,7 +637,7 @@ UpdateCohortGroups <- function(sim){
   
   # Update cbm_vars state.
   sim$cbm_vars$state <- merge(
-    cohorts[, .(row_idx, gcID, age, speciesCode, sw, row_idx_prev)],
+    cohorts[, .(row_idx, gcID, age, speciesCode, row_idx_prev)],
     sim$cbm_vars$state[, .(row_idx, delay, admin_name, eco_id, land_class_id, last_disturbance_type, time_since_last_disturbance, time_since_land_use_change, enabled)],
     by.x = "row_idx_prev",
     by.y = "row_idx",
@@ -710,6 +646,7 @@ UpdateCohortGroups <- function(sim){
   sim$cbm_vars$state[, row_idx_prev := NULL]
   sim$cbm_vars$state[, age := age - 1L]
   sim$cbm_vars$state <- unique(sim$cbm_vars$state, by = "row_idx")
+  sim$cbm_vars$state[sim$gcMeta, sw := sw, on = "gcID"]
   setkey(sim$cbm_vars$state, row_idx)
   
   return(invisible(sim))

--- a/LandRCBM_split3pools.Rmd
+++ b/LandRCBM_split3pools.Rmd
@@ -138,8 +138,6 @@ The merchantable proportion of stemwood biomass is calculated in this way for ea
 | gcIncrements      | Data table | Growth increment matrix. Provides increments for each pool in each pixel and cohort |
 | gcMeta            | Data table | Growth curve metadata                                           |
 | summaryAGB        | Data table | Sum of carbon mass for each species and above ground pools at each time step |
-| yieldTablesCumulative | Data table | Yield tables intended to supply CBM spinup requirements     |
-| yieldTablesId     | Data table | Table spatially linking yield tables to pixels                  |
 
 
 ### Links to other modules

--- a/R/generateCohortDT.R
+++ b/R/generateCohortDT.R
@@ -1,17 +1,17 @@
-generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
+generateCohortDT <- function(cohortData, pixelGroupMap, standDT, yieldTablesId){
+  
   # get the pixelGroup for each pixelIndex
+  # `na.omit` removes pixels not forested.
   cohortDT <- data.table(
     pixelGroup = as.integer(pixelGroupMap[])
   ) 
   cohortDT <- cohortDT[, pixelIndex := .I] |> na.omit()
+  
   # add cohort information for each pixelIndex
   cohortDT <- merge(cohortDT,
                     cohortData[age > 0,.(speciesCode, age, pixelGroup)],
+                    by = "pixelGroup",
                     allow.cartesian = TRUE)
-  
-  # add sw/hw information of species
-  cohortDT <- addForestType(cohortDT)
-  setorder(cohortDT, pixelIndex, speciesCode, age)
   
   if (!is.null(yieldTablesId)){
     # add the yield table index
@@ -19,7 +19,7 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
     cohortDT <- merge(cohortDT, yieldTablesId, by = "pixelIndex", all.x = TRUE)
     
     # Get the species combinations per yieldTableIndex from the original data
-    species_combos <- unique(cohortDT[, .(yieldTableIndex, speciesCode, sw)])
+    species_combos <- unique(cohortDT[, .(yieldTableIndex, speciesCode)])
     
     # Find pixels in yieldTablesId that are not in original cohortDT
     missing_pixels <- setdiff(yieldTablesId[yieldTableIndex != 0, pixelIndex], unique(cohortDT$pixelIndex))
@@ -34,25 +34,31 @@ generateCohortDT <- function(cohortData, pixelGroupMap, yieldTablesId){
       # Add age = 0
       new_rows[, age := 0L]
       
-      # Keep same column order as final table
-      setcolorder(new_rows, c("pixelIndex", "speciesCode", "age", "yieldTableIndex", "sw"))
-      
       # Bind to cohortDT
       cohortDT <- rbindlist(list(cohortDT, new_rows), use.names = TRUE, fill = TRUE)
     }
-    
-    # add the index for individual cohorts
-    cohortDT[, cohortID := .I]
-    
-    # Add the growth curve index: 1 per species x yield table
-    cohortDT[, gcID := .GRP, by = .(yieldTableIndex, speciesCode)]
-    
-    # Keep final columns in desired order
-    cohortDT <- cohortDT[, .(cohortID, pixelIndex, speciesCode, age, gcID, yieldTableIndex, sw)]
   } else {
     stop("yieldTablesId needs to cannot be NULL")
   }
   
+  # Create a new, unique ID for each unique combination of original yield 
+  # table index and CBM spatial units. This handles cases
+  # where one yield curve spans multiple ecozones/jurisdictions.
+  cohortDT <- merge(cohortDT, standDT[, .(pixelIndex, admin_abbrev, eco_id)], by = "pixelIndex")
+  setcolorder(cohortDT, c("pixelIndex", "speciesCode", "age"))
+  cohortDT[, gcID := .GRP, by = .(admin_abbrev, eco_id, yieldTableIndex, speciesCode)]
+  
+  # add the index for individual cohorts
+  cohortDT[, cohortID := .I]
   setkey(cohortDT, cohortID)
+  
+  # Keep final columns in desired order
+  cohortDT <- cohortDT[, .(cohortID, pixelIndex, admin_abbrev, eco_id, speciesCode, age, yieldTableIndex, gcID)]
+  
+  # Ensure cohort generation worked
+  if (is.null(cohortDT) || nrow(cohortDT) == 0) {
+    stop("generateCohortDT failed.")
+  }
+  
   return(cohortDT)
 }

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -34,7 +34,7 @@ gg_speciessummary <- function(x) {
 }
 
 gg_yieldCurves <- function(x, title){
-  ggplot(x, aes(age, totB, color = speciesCode)) + geom_line() + theme_bw() +
+  ggplot(x, aes(age, biomass, color = speciesCode)) + geom_line() + theme_bw() +
     #scale_color_manual(values = colors) +
     facet_wrap(~yieldTableIndex) +
     labs(title = title, x = "Age", y = 'AGB (tonnes/ha)', color = "Species") +

--- a/tests/testthat/helper-checks.R
+++ b/tests/testthat/helper-checks.R
@@ -3,22 +3,27 @@
 # @param spinup logical. Checks match expected state after the spinup.
 check_module_outputs <- function(simTest, spinup = FALSE){
   
-  # yieldTablesId
-  expect_is(simTest$yieldTablesId, "data.table")
-  expect_in(c("pixelIndex", "yieldTableIndex"), 
-            names(simTest$yieldTablesId))
+  # abovegroundbiomass
+  expect_is(simTest$aboveGroundBiomass, "data.table")
+  expect_in(c("pixelIndex", "speciesCode", "age", "merch", "foliage", "other"), 
+            names(simTest$aboveGroundBiomass))
   
-  # yieldTablesCumulative
-  expect_is(simTest$yieldTablesCumulative, "data.table")
-  expect_in(c("speciesCode", "age", "yieldTableIndex", "merch", "foliage", "other"),
-            names(simTest$yieldTablesCumulative))
-  
-  expect_true(all(simTest$yieldTablesCumulative$yieldTableIndex %in% simTest$yieldTablesId$yieldTableIndex))
+  ## check that total biomass per species match cohortData
+  expectedSpeciesB <- simTest$cohortData[, .(total_biomass = sum(B)/200), by = speciesCode]
+  resultSpeciesB <- copy(simTest$aboveGroundBiomass)[, B := merch + foliage + other]
+  resultSpeciesB <- resultSpeciesB[, .(total_biomass = sum(B)), by = speciesCode]
+  expect_equal(expectedSpeciesB[order(speciesCode)], resultSpeciesB[order(speciesCode)])
   
   # gcMeta
-  expect_is(simTest$gcMeta, "data.table")
-  expect_in(c("gcID", "speciesCode", "sw"),
-            names(simTest$gcMeta))
+  if (spinup){
+    expect_in(c("gcID", "admin_abbrev", "eco_id", "speciesCode", "CanfiCode", "sw"),
+              names(simTest$gcMeta))
+    expect_in("yieldTableIndex", names(simTest$gcMeta))
+    expect_true(all(simTest$gcMeta$yieldTableIndex %in% simTest$yieldTablesId$yieldTableIndex))
+  }else{
+    expect_in(c("gcID", "speciesCode", "sw"),
+              names(simTest$gcMeta))
+  }
   
   # gcIncrements
   expect_is(simTest$gcIncrements, "data.table")
@@ -28,10 +33,7 @@ check_module_outputs <- function(simTest, spinup = FALSE){
   expect_setequal(simTest$gcIncrements$gcID, simTest$gcMeta$gcID)
   
   if (spinup){
-    expect_in("yieldTableIndex", names(simTest$gcIncrements))
     expect_equal(nrow(simTest$gcIncrements), nrow(simTest$yieldTablesCumulative))
-    expect_true(all(simTest$gcIncrements$yieldTableIndex %in% simTest$yieldTablesId$yieldTableIndex))
-    
   }else{
     expect_setequal(simTest$gcIncrements$gcID, simTest$gcMeta$gcID)
     expect_equal(nrow(simTest$gcIncrements), nrow(simTest$gcMeta))
@@ -43,17 +45,6 @@ check_module_outputs <- function(simTest, spinup = FALSE){
             names(simTest$cohortDT))
   
   expect_true(all(simTest$cohortDT$gcID %in% simTest$gcMeta$gcID))
-  
-  # abovegroundbiomass
-  expect_is(simTest$aboveGroundBiomass, "data.table")
-  expect_in(c("pixelIndex", "speciesCode", "age", "merch", "foliage", "other"), 
-            names(simTest$aboveGroundBiomass))
-  
-  ## check that total biomass per species match cohortData
-  expectedSpeciesB <- simTest$cohortData[, .(total_biomass = sum(B)/200), by = speciesCode]
-  resultSpeciesB <- copy(simTest$aboveGroundBiomass)[, B := merch + foliage + other]
-  resultSpeciesB <- resultSpeciesB[, .(total_biomass = sum(B)), by = speciesCode]
-  expect_equal(expectedSpeciesB[order(speciesCode)], resultSpeciesB[order(speciesCode)])
   
   # summaryAGB
   if (!spinup){

--- a/tests/testthat/test-2-generateCohortDT.R
+++ b/tests/testthat/test-2-generateCohortDT.R
@@ -10,6 +10,11 @@ test_that("function generateDt works", {
     B = c(10, 500, 300, 250),
     age = c(10, 10, 100, 0)
   )
+  standDT <- data.table::data.table(
+    pixelIndex   = 1:4,
+    admin_abbrev = "BC",
+    eco_id       = 1
+  )
   yieldTablesId <- data.table(
     pixelIndex = c(1, 2, 3), 
     yieldTableIndex = c(1001, 1002, 1001) 
@@ -18,12 +23,12 @@ test_that("function generateDt works", {
   ## Runs with yieldTablesId
   
   # Run function
-  result <- generateCohortDT(cohortData, pixelGroupMap, yieldTablesId)
+  result <- generateCohortDT(cohortData, pixelGroupMap, standDT, yieldTablesId)
   # Tests
   expect_is(result, "data.table")
   expect_equal(nrow(result), 5)
-  expected_cols <- c("cohortID", "pixelIndex", "speciesCode", 
-                     "age", "gcID", "yieldTableIndex", "sw")
+  expected_cols <- c("cohortID", "pixelIndex", "admin_abbrev", "eco_id", 
+                     "speciesCode", "age", "yieldTableIndex", "gcID")
   expect_named(result, expected_cols, ignore.order = TRUE)
   expect_false(0 %in% result$age)
   
@@ -40,6 +45,6 @@ test_that("function generateDt works", {
   expect_false(any(gcid_abie %in% gcid_pinu))
 
   # Run function
-  expect_error(generateCohortDT(cohortData, pixelGroupMap, yieldTablesId = NULL))
+  expect_error(generateCohortDT(cohortData, pixelGroupMap, standDT, yieldTablesId = NULL))
 
 })


### PR DESCRIPTION
In updating the module for CBM4 I believe I stumbled upon a simplification that can be done now as a stepping stone in that transition. I am suggesting this change separately because this is predicated by my understanding that `yieldTablesId` and `yieldTablesCumulative` are not used as inputs for any other modules so @DominiqueCaron please let me know if I have missed an application for them. Initially I looking to move all growth curve attributes out of `gcIncrements` into the `gcMeta` table (e.g. `yieldTablesIndex`, `sw`) to save memory which is also accomplished here.

The `splitInit` function calls the `SplitYieldTables` function to create `cohortDT`, `gcMeta`, and `gcIncrements` for the **CBM_core** spinup. It also updates `yieldTablesId` and `yieldTablesCumulative` ("yield tables") in the process. In this update, the yield tables are left as-is and instead the `gcMeta` and `gcIncrements` objects are created to contain all the updated data that stems from those tables.

This skips the step where the `yieldTableIndex` ID is updated which might make it easier to review the data flowing in and out of the **Biomass_yieldTables** module in retrospect. `gcMeta` keeps the original `yieldTableIndex` column.

Plotting functions have been updated to use `gcMeta` and `gcIncrements` instead of the updated yield tables. `gcIncrements` keeps the `merch`, `foliage` and `other` columns that are used by `PlotYieldTablesPools` (these are ignored by **CBM_core** which uses `merch_inc`, `foliage_inc`, `other_inc`).

***Current flow of `SplitYieldTables`:***
1. `spatialDT` is created as a merge between `standDT` and `yieldTablesId`
2. Using `spatialDT`, `sim$yieldTablesId`  is updated so that `yieldTableIndex` is unique to `.(yieldTableIndex, admin_abbrev, eco_id)`
3. `generateCohortDt` function is called: `cohortDT` is created as a merge between `cohortData`, `pixelGroupMap`, `yieldTablesId` and adds column `sw`. `gcID` is set as unique groups of `.(yieldTableIndex, speciesCode)` where the `yieldTableIndex` is an updated ID that is unique to `.(yieldTableIndex, admin_abbrev, eco_id)` 
5. `sim$cohortDT` is saved to the simList as `cohortDT[, .(cohortID, pixelIndex, age, speciesCode, gcID)]`
6. `sim$gcMeta` is saved to the simList as `unique(cohortDT[, .(gcID, speciesCode, sw)])`
7. `gcIncrements` is initiated by merging `spatialDT` and `yieldTablesCumulative` on `c("speciesCode", "yieldTableIndex")` and adds attribute `CanfiCode`.
9. `gcIncrements` is split into pools with `CBMutils::cumPoolsCreateAGB` and increments are calculated
10. `gcIncrements` is merged with `cohortDT` to add the `gcID` column.
11. `sim$gcIncrements` is finalized as `cumPools[,.(gcID, age, yieldTableIndex, merch_inc, foliage_inc, other_inc)]`

***Updated flow of `SplitYieldTables`:***
1. `generateCohortDt` function is called: `cohortDT` is created as a merge between `cohortData`, `pixelGroupMap`, `yieldTablesId`, and `standDT`. `gcID` is set as unique groups of `.(admin_abbrev, eco_id, yieldTableIndex, speciesCode)`
3. `sim$cohortDT` is saved to the simList as `cohortDT[, .(cohortID, pixelIndex, age, speciesCode, gcID)]`
4. `sim$gcMeta` is saved to the simList as `unique(cohortDT[, .(gcID, admin_abbrev, eco_id, yieldTableIndex, speciesCode)])` and adds attributes `sw` and `CanfiCode`. 
6. `gcIncrements` is initiated by merging `sim$gcMeta` and `yieldTablesCumulative` on `c("speciesCode", "yieldTableIndex")`
7. `gcIncrements` is split into pools with `CBMutils::cumPoolsCreateAGB` and increments are calculated
8. `sim$gcIncrements` is finalized as `cumPools[,.(gcID, age, merch, foliage, other, merch_inc, foliage_inc, other_inc)]`
